### PR TITLE
Added or_else filter, partially addresses #411

### DIFF
--- a/docs/variables.txt
+++ b/docs/variables.txt
@@ -21,17 +21,22 @@ $(args:0-1|urlencode) - urlencode the first parameter
 
 Available filters:
         available_filters = {
-                'strftime': _filter_strftime,
-                'lower': lambda var, args: var.lower(),
-                'upper': lambda var, args: var.upper(),
-                'time_since_minutes': lambda var, args: 'no time' if var == 0 else time_since(var * 60, 0, format='long'),
-                'time_since': lambda var, args: 'no time' if var == 0 else time_since(var, 0, format='long'),
-                'time_since_dt': _filter_time_since_dt,
-                'urlencode': _filter_urlencode,
-                'join': _filter_join,
-                'number_format': _filter_number_format,
-                'add': _filter_add,
-}
+            "strftime": _filter_strftime,
+            "lower": lambda var, args: var.lower(),
+            "upper": lambda var, args: var.upper(),
+            "time_since_minutes": lambda var, args: "no time"
+            if var == 0
+            else time_since(var * 60, 0, time_format="long"),
+            "time_since": lambda var, args: "no time" if var == 0 else time_since(var, 0, time_format="long"),
+            "time_since_dt": _filter_time_since_dt,
+            "urlencode": _filter_urlencode,
+            "join": _filter_join,
+            "number_format": _filter_number_format,
+            "add": _filter_add,
+            "or_else": _filter_or_else,
+            "or_broadcaster": self._filter_or_broadcaster,
+            "or_streamer": self._filter_or_broadcaster,
+        }
 
 
 special substitutions:

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -949,6 +949,7 @@ class Bot:
             "join": _filter_join,
             "number_format": _filter_number_format,
             "add": _filter_add,
+            "or_else": _filter_or_else,
         }
         if f.name in available_filters:
             return available_filters[f.name](resp, f.arguments)
@@ -1005,3 +1006,9 @@ def _filter_add(var, args):
         return str(int(var) + int(args[0]))
     except:
         return ""
+
+def _filter_or_else(var, args):
+    if var is None or len(var) <= 0:
+        return args[0]
+    else:
+        return var

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -1007,6 +1007,7 @@ def _filter_add(var, args):
     except:
         return ""
 
+
 def _filter_or_else(var, args):
     if var is None or len(var) <= 0:
         return args[0]

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -934,8 +934,7 @@ class Bot:
 
         sys.exit(0)
 
-    @staticmethod
-    def apply_filter(resp, f):
+    def apply_filter(self, resp, f):
         available_filters = {
             "strftime": _filter_strftime,
             "lower": lambda var, args: var.lower(),
@@ -950,10 +949,15 @@ class Bot:
             "number_format": _filter_number_format,
             "add": _filter_add,
             "or_else": _filter_or_else,
+            "or_broadcaster": self._filter_or_broadcaster,
+            "or_streamer": self._filter_or_broadcaster,
         }
         if f.name in available_filters:
             return available_filters[f.name](resp, f.arguments)
         return resp
+
+    def _filter_or_broadcaster(self, var, args):
+        return _filter_or_else(var, self.streamer)
 
     def find_unique_urls(self, message):
         from pajbot.modules.linkchecker import find_unique_urls


### PR DESCRIPTION
The reason the first commit doesn't close #411 is because a command defined as `$(strictargs:0-1|or_else($(tb:broadcaster)))` actually evaluates to `󠀀$(strictargs:0-1|or_else(randers))` in chat, and is not further expanded.
