### PR TITLE
Fix the "dubtrack room not updating properly" error

### DIFF
--- a/pajbot/models/sock.py
+++ b/pajbot/models/sock.py
@@ -50,7 +50,7 @@ class SocketManager:
 
             for handler in self.handlers[message["channel"]]:
                 # invokes the handler on the bot's main thread (the IRC event loop)
-                self.callback(lambda: handler(parsed_data))
+                self.callback(handler, (parsed_data, ))
 
         self.pubsub.close()
 

--- a/pajbot/models/sock.py
+++ b/pajbot/models/sock.py
@@ -50,7 +50,7 @@ class SocketManager:
 
             for handler in self.handlers[message["channel"]]:
                 # invokes the handler on the bot's main thread (the IRC event loop)
-                self.callback(handler, (parsed_data, ))
+                self.callback(handler, (parsed_data,))
 
         self.pubsub.close()
 


### PR DESCRIPTION
Putting a lambda in the callback resulted in the "classic javascript loop
error", where handler is basically a reference to the iterator, so when
the lambda is actually invoked, handler points on the last member of the
array, leading to the last handler being invoked N times where N is the
length of self.handlers[message["channel"]]