### PR TITLE
Changed Math Emote to PogChamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Remember to bring your dependencies up to date with
 - Bugfix: You can now use the same phrases (1k, "all", etc.) with the `!givepoints` command.
 - Documentation Bugfix: `$(urlfetch)` returns the response body, not request
   body
+  Minor: Changed Math function Emote from Kappa to PogChamp
 
 <!--
 - Internal: New (stupider) migrations system that directly uses SQL, and can additionally

--- a/pajbot/modules/math.py
+++ b/pajbot/modules/math.py
@@ -125,7 +125,7 @@ class MathModule(BaseModule):
         if expr_res is None:
             return False
 
-        emote = "Kappa"
+        emote = "PogChamp"
         try:
             if int(expr_res) == 69 or expr_res == 69.69:
                 emote = "Kreygasm"


### PR DESCRIPTION
Kappa is a great emote but a horrible emote for a math function/command, it makes you think the bot is lying to you about the answer to your math question.

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
