### PR TITLE
Pajlada add minimum level to configure module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Remember to bring your dependencies up to date with
   users that changed their twitch name. (Level 2000 only).
   `./scripts/transfer-{all,sql,redis}` scripts have been removed.
 - Minor: Removed `!reload` command since it did nothing.
+- Minor: Modules can now be configured to only allow users above a certain level to configure them. #108
 - Bugfix: A series of bugs (including the `!laststream` command sometimes not
   working) caused by a mismatch of datetime-aware and datetime-naive objects.
 - Bugfix: If redis is busy loading data, the bot no longer exists, and waits for

--- a/pajbot/modules/base.py
+++ b/pajbot/modules/base.py
@@ -110,6 +110,7 @@ class BaseModule:
     CATEGORY = "Uncategorized"
     HIDDEN = False
     MODULE_TYPE = ModuleType.TYPE_NORMAL
+    CONFIGURE_LEVEL = 500
 
     def __init__(self, bot):
         """ Initialize any dictionaries the module might or might not use. """

--- a/pajbot/web/routes/admin/modules.py
+++ b/pajbot/web/routes/admin/modules.py
@@ -33,6 +33,11 @@ def init(page):
         module_manager = ModuleManager(None).load(do_reload=False)
         current_module = find(lambda m: m.ID == module_id, module_manager.all_modules)
 
+        user = options["user"]
+
+        if user.level < current_module.CONFIGURE_LEVEL:
+            return render_template("errors/403.html", extra_message="You do not have permission to configure this module."), 403
+
         if current_module is None:
             return render_template("admin/module_404.html"), 404
 
@@ -80,6 +85,6 @@ def init(page):
 
             SocketClientManager.send("module.update", payload)
 
-            AdminLogManager.post("Module edited", options["user"], current_module.NAME)
+            AdminLogManager.post("Module edited", user, current_module.NAME)
 
             return render_template("admin/configure_module.html", module=current_module, sub_modules=sub_modules)

--- a/pajbot/web/routes/admin/modules.py
+++ b/pajbot/web/routes/admin/modules.py
@@ -36,7 +36,12 @@ def init(page):
         user = options["user"]
 
         if user.level < current_module.CONFIGURE_LEVEL:
-            return render_template("errors/403.html", extra_message="You do not have permission to configure this module."), 403
+            return (
+                render_template(
+                    "errors/403.html", extra_message="You do not have permission to configure this module."
+                ),
+                403,
+            )
 
         if current_module is None:
             return render_template("admin/module_404.html"), 404

--- a/templates/admin/modules.html
+++ b/templates/admin/modules.html
@@ -29,7 +29,7 @@
                     {% endif %}
                 </td>
                 <td class="right aligned collapsing">
-                <button class="ui compact button edit-row"><i class="icon setting"></i>Configure</button></td>
+                <button class="ui compact button edit-row" {{- 'disabled' if session.user.level < row.CONFIGURE_LEVEL else '' -}}><i class="icon setting"></i>Configure</button></td>
             </tr>
 {% endfor %}
         </tbody>

--- a/templates/errors/403.html
+++ b/templates/errors/403.html
@@ -4,4 +4,7 @@
 {% block body %}
 <h1>403</h1>
 <p>You shouldn't be here.</p>
+{% if extra_message %}
+<p>{{ extra_message }}</p>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
 Implement "minimum level to configure" support for modules.

This will do 3 things:
- When a moderator is viewing the list of modules, the configure button will be disabled if they are not high enough level to configure the module.
- If a moderator tries to view the /edit/<moduleid> page, a 403 error will be thrown explaining that they aren't allowed to configure this module.
- If a moderator tries to send a post request to configure the module to the /edit/<moduleid> page, the same 403 error page will be thrown.

Fixes #108

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
