### PR TITLE
Revert to using += to increment user's lines

### DIFF
--- a/pajbot/modules/linefarming.py
+++ b/pajbot/modules/linefarming.py
@@ -23,9 +23,7 @@ class LineFarmingModule(BaseModule):
 
     def on_pubmsg(self, source, **rest):
         if self.bot.is_online or self.settings["count_offline"] is True:
-            # this funky syntax makes SQLAlchemy increment
-            # the num_lines atomically with SET num_lines=("user".num_lines + 1)
-            source.num_lines = User.num_lines + 1
+            source.num_lines += 1
 
     def enable(self, bot):
         HandlerManager.add_handler("on_pubmsg", self.on_pubmsg)


### PR DESCRIPTION
Doing it the "atomic" way was causing str(user.num_lines) to become ""user".num_lines + :num_lines_1" which is not intended



Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
