### PR TITLE
Initialize defaults in the constructor

### DIFF
--- a/pajbot/models/duel.py
+++ b/pajbot/models/duel.py
@@ -17,14 +17,26 @@ class UserDuelStats(Base):
     __tablename__ = "user_duel_stats"
 
     user_id = Column(INT, ForeignKey("user.id", ondelete="CASCADE"), primary_key=True, autoincrement=False)
-    duels_won = Column(INT, nullable=False, default=0)
-    duels_total = Column(INT, nullable=False, default=0)
-    points_won = Column(INT, nullable=False, default=0)
-    points_lost = Column(INT, nullable=False, default=0)
+    duels_won = Column(INT, nullable=False)
+    duels_total = Column(INT, nullable=False)
+    points_won = Column(INT, nullable=False)
+    points_lost = Column(INT, nullable=False)
     last_duel = Column(UtcDateTime(), nullable=True)
-    current_streak = Column(INT, nullable=False, default=0)
-    longest_winstreak = Column(INT, nullable=False, default=0)
-    longest_losestreak = Column(INT, nullable=False, default=0)
+    current_streak = Column(INT, nullable=False)
+    longest_winstreak = Column(INT, nullable=False)
+    longest_losestreak = Column(INT, nullable=False)
+
+    def __init__(self, *args, **kwargs):
+        self.duels_won = 0
+        self.duels_total = 0
+        self.points_won = 0
+        self.points_lost = 0
+        self.last_duel = None
+        self.current_streak = 0
+        self.longest_winstreak = 0
+        self.longest_losestreak = 0
+
+        super().__init__(*args, **kwargs)
 
     user = relationship(
         "User", cascade="", uselist=False, backref=backref("duel_stats", uselist=False, cascade="", lazy="select")

--- a/pajbot/models/user.py
+++ b/pajbot/models/user.py
@@ -8,7 +8,6 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship, foreign
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.sql import functions
-from sqlalchemy.sql.functions import now
 from sqlalchemy_utc import UtcDateTime
 
 from pajbot import utils
@@ -70,30 +69,43 @@ class User(Base):
     #     user.name = 'Snusbot'
     # This would issue an `UPDATE` command that sets user.login even if the login was already "snusbot" before,
     # and so the login_last_updated becomes updated on the database side via the trigger.
-    login_last_updated = Column(UtcDateTime(), nullable=False, default=now(), server_default="NOW()")
+    login_last_updated = Column(UtcDateTime(), nullable=False, server_default="NOW()")
 
     # Twitch user display name
     name = Column(TEXT, nullable=False, index=True)
 
-    level = Column(INT, nullable=False, default=100, server_default="100")
-    points = Column(BIGINT, nullable=False, default=0, server_default="0", index=True)
-    subscriber = Column(BOOLEAN, nullable=False, default=False, server_default="FALSE")
-    moderator = Column(BOOLEAN, nullable=False, default=False, server_default="FALSE")
-    time_in_chat_online = Column(
-        Interval, nullable=False, default=timedelta(minutes=0), server_default="INTERVAL '0 minutes'"
-    )
-    time_in_chat_offline = Column(
-        Interval, nullable=False, default=timedelta(minutes=0), server_default="INTERVAL '0 minutes'"
-    )
-    num_lines = Column(BIGINT, nullable=False, default=0, server_default="0", index=True)
-    tokens = Column(INT, nullable=False, default=0, server_default="0")
-    last_seen = Column(UtcDateTime(), nullable=True, default=None, server_default="NULL")
-    last_active = Column(UtcDateTime(), nullable=True, default=None, server_default="NULL")
-    ignored = Column(BOOLEAN, nullable=False, default=False, server_default="FALSE")
-    banned = Column(BOOLEAN, nullable=False, default=False, server_default="FALSE")
-    timeout_end = Column(UtcDateTime(), nullable=True, default=None, server_default="NULL")
+    level = Column(INT, nullable=False, server_default="100")
+    points = Column(BIGINT, nullable=False, server_default="0", index=True)
+    subscriber = Column(BOOLEAN, nullable=False, server_default="FALSE")
+    moderator = Column(BOOLEAN, nullable=False, server_default="FALSE")
+    time_in_chat_online = Column(Interval, nullable=False, server_default="INTERVAL '0 minutes'")
+    time_in_chat_offline = Column(Interval, nullable=False, server_default="INTERVAL '0 minutes'")
+    num_lines = Column(BIGINT, nullable=False, server_default="0", index=True)
+    tokens = Column(INT, nullable=False, server_default="0")
+    last_seen = Column(UtcDateTime(), nullable=True, server_default="NULL")
+    last_active = Column(UtcDateTime(), nullable=True, server_default="NULL")
+    ignored = Column(BOOLEAN, nullable=False, server_default="FALSE")
+    banned = Column(BOOLEAN, nullable=False, server_default="FALSE")
+    timeout_end = Column(UtcDateTime(), nullable=True, server_default="NULL")
 
     _rank = relationship("UserRank", primaryjoin=foreign(id) == UserRank.user_id, lazy="select")
+
+    def __init__(self, *args, **kwargs):
+        self.level = 100
+        self.points = 0
+        self.subscriber = False
+        self.moderator = False
+        self.time_in_chat_online = timedelta(minutes=0)
+        self.time_in_chat_offline = timedelta(minutes=0)
+        self.num_lines = 0
+        self.tokens = 0
+        self.last_seen = None
+        self.last_active = None
+        self.ignored = False
+        self.banned = False
+        self.timeout_end = None
+
+        super().__init__(*args, **kwargs)
 
     @hybrid_property
     def username(self):


### PR DESCRIPTION
So from what I understand, there's three ways to do defaults if you are using the declarative API/system in SQLAlchemy:

- `server_default` is for creating/altering tables with alembic etc, and is otherwise purely declarative, it marks that the column has a `DEFAULT ...` expression on the SQL server side
- `default` is for `INSERT` or `UPDATE` statements only (they don't get automatically assigned to the new model objects)
- in the constructor, before a call to `super().__init__(*args, **kwargs)`: The super constructor infers properties to set, based on `*args` and `**kwargs` (E.g. `User(id='12345')` will assign `id` in that super constructor)

My conclusion is to continue to use `server_default` (to show what's going on on the SQL side, to help the reader understand that column has a default) and the assignment in the constructor since it achieves the same as `default=` + some more (sets the default on new models as well.)

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
