### PR TITLE
Duel stats: final fix

### DIFF
--- a/pajbot/models/duel.py
+++ b/pajbot/models/duel.py
@@ -17,14 +17,26 @@ class UserDuelStats(Base):
     __tablename__ = "user_duel_stats"
 
     user_id = Column(INT, ForeignKey("user.id", ondelete="CASCADE"), primary_key=True, autoincrement=False)
-    duels_won = Column(INT, nullable=False, default=0)
-    duels_total = Column(INT, nullable=False, default=0)
-    points_won = Column(INT, nullable=False, default=0)
-    points_lost = Column(INT, nullable=False, default=0)
+    duels_won = Column(INT, nullable=False)
+    duels_total = Column(INT, nullable=False)
+    points_won = Column(INT, nullable=False)
+    points_lost = Column(INT, nullable=False)
     last_duel = Column(UtcDateTime(), nullable=True)
-    current_streak = Column(INT, nullable=False, default=0)
-    longest_winstreak = Column(INT, nullable=False, default=0)
-    longest_losestreak = Column(INT, nullable=False, default=0)
+    current_streak = Column(INT, nullable=False)
+    longest_winstreak = Column(INT, nullable=False)
+    longest_losestreak = Column(INT, nullable=False)
+
+    def __init__(self, *args, **kwargs):
+        self.duels_won = 0
+        self.duels_total = 0
+        self.points_won = 0
+        self.points_lost = 0
+        self.last_duel = None
+        self.current_streak = 0
+        self.longest_winstreak = 0
+        self.longest_losestreak = 0
+
+        super().__init__(*args, **kwargs)
 
     user = relationship(
         "User", cascade="", uselist=False, backref=backref("duel_stats", uselist=False, cascade="", lazy="select")

--- a/pajbot/models/duel.py
+++ b/pajbot/models/duel.py
@@ -37,7 +37,7 @@ class UserDuelStats(Base):
 
         super().__init__(*args, **kwargs)
 
-    user = relationship("User", cascade="save-update, merge", back_populates="duel_stats")
+    user = relationship("User", cascade="save-update, merge", lazy="joined", back_populates="duel_stats")
 
     @hybrid_property
     def duels_lost(self):
@@ -50,13 +50,6 @@ class UserDuelStats(Base):
     @hybrid_property
     def profit(self):
         return self.points_won - self.points_lost
-
-    @staticmethod
-    def for_user(db_session, user):
-        if user.duel_stats is None:
-            user.duel_stats = UserDuelStats(user_id=user.id)
-            db_session.add(user.duel_stats)
-        return user.duel_stats
 
     def won(self, points_won):
         self.duels_won += 1

--- a/pajbot/models/duel.py
+++ b/pajbot/models/duel.py
@@ -3,7 +3,6 @@ import logging
 from sqlalchemy import Column, INT
 from sqlalchemy import ForeignKey
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import backref
 from sqlalchemy.orm import relationship
 from sqlalchemy_utc import UtcDateTime
 
@@ -38,9 +37,7 @@ class UserDuelStats(Base):
 
         super().__init__(*args, **kwargs)
 
-    user = relationship(
-        "User", cascade="", uselist=False, backref=backref("duel_stats", uselist=False, cascade="", lazy="select")
-    )
+    user = relationship("User", cascade="save-update, merge", back_populates="duel_stats")
 
     @hybrid_property
     def duels_lost(self):

--- a/pajbot/models/user.py
+++ b/pajbot/models/user.py
@@ -8,7 +8,6 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship, foreign
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.sql import functions
-from sqlalchemy.sql.functions import now
 from sqlalchemy_utc import UtcDateTime
 
 from pajbot import utils
@@ -70,30 +69,43 @@ class User(Base):
     #     user.name = 'Snusbot'
     # This would issue an `UPDATE` command that sets user.login even if the login was already "snusbot" before,
     # and so the login_last_updated becomes updated on the database side via the trigger.
-    login_last_updated = Column(UtcDateTime(), nullable=False, default=now(), server_default="NOW()")
+    login_last_updated = Column(UtcDateTime(), nullable=False, server_default="NOW()")
 
     # Twitch user display name
     name = Column(TEXT, nullable=False, index=True)
 
-    level = Column(INT, nullable=False, default=100, server_default="100")
-    points = Column(BIGINT, nullable=False, default=0, server_default="0", index=True)
-    subscriber = Column(BOOLEAN, nullable=False, default=False, server_default="FALSE")
-    moderator = Column(BOOLEAN, nullable=False, default=False, server_default="FALSE")
-    time_in_chat_online = Column(
-        Interval, nullable=False, default=timedelta(minutes=0), server_default="INTERVAL '0 minutes'"
-    )
-    time_in_chat_offline = Column(
-        Interval, nullable=False, default=timedelta(minutes=0), server_default="INTERVAL '0 minutes'"
-    )
-    num_lines = Column(BIGINT, nullable=False, default=0, server_default="0", index=True)
-    tokens = Column(INT, nullable=False, default=0, server_default="0")
-    last_seen = Column(UtcDateTime(), nullable=True, default=None, server_default="NULL")
-    last_active = Column(UtcDateTime(), nullable=True, default=None, server_default="NULL")
-    ignored = Column(BOOLEAN, nullable=False, default=False, server_default="FALSE")
-    banned = Column(BOOLEAN, nullable=False, default=False, server_default="FALSE")
-    timeout_end = Column(UtcDateTime(), nullable=True, default=None, server_default="NULL")
+    level = Column(INT, nullable=False, server_default="100")
+    points = Column(BIGINT, nullable=False, server_default="0", index=True)
+    subscriber = Column(BOOLEAN, nullable=False, server_default="FALSE")
+    moderator = Column(BOOLEAN, nullable=False, server_default="FALSE")
+    time_in_chat_online = Column(Interval, nullable=False, server_default="INTERVAL '0 minutes'")
+    time_in_chat_offline = Column(Interval, nullable=False, server_default="INTERVAL '0 minutes'")
+    num_lines = Column(BIGINT, nullable=False, server_default="0", index=True)
+    tokens = Column(INT, nullable=False, server_default="0")
+    last_seen = Column(UtcDateTime(), nullable=True, server_default="NULL")
+    last_active = Column(UtcDateTime(), nullable=True, server_default="NULL")
+    ignored = Column(BOOLEAN, nullable=False, server_default="FALSE")
+    banned = Column(BOOLEAN, nullable=False, server_default="FALSE")
+    timeout_end = Column(UtcDateTime(), nullable=True, server_default="NULL")
 
     _rank = relationship("UserRank", primaryjoin=foreign(id) == UserRank.user_id, lazy="select")
+
+    def __init__(self, *args, **kwargs):
+        self.level = 100
+        self.points = 0
+        self.subscriber = False
+        self.moderator = False
+        self.time_in_chat_online = timedelta(minutes=0)
+        self.time_in_chat_offline = timedelta(minutes=0)
+        self.num_lines = 0
+        self.tokens = 0
+        self.last_seen = None
+        self.last_active = None
+        self.ignored = False
+        self.banned = False
+        self.timeout_end = None
+
+        super().__init__(*args, **kwargs)
 
     @hybrid_property
     def username(self):

--- a/pajbot/models/user.py
+++ b/pajbot/models/user.py
@@ -14,6 +14,7 @@ from pajbot import utils
 from pajbot.exc import FailedCommand
 from pajbot.managers.db import Base
 from pajbot.managers.redis import RedisManager
+from pajbot.models.duel import UserDuelStats
 
 log = logging.getLogger(__name__)
 
@@ -106,6 +107,10 @@ class User(Base):
         self.timeout_end = None
 
         super().__init__(*args, **kwargs)
+
+    duel_stats = relationship(
+        UserDuelStats, uselist=False, cascade="all, delete-orphan", passive_deletes=True, back_populates="user"
+    )
 
     @hybrid_property
     def username(self):

--- a/pajbot/models/user.py
+++ b/pajbot/models/user.py
@@ -108,7 +108,7 @@ class User(Base):
 
         super().__init__(*args, **kwargs)
 
-    duel_stats = relationship(
+    _duel_stats = relationship(
         UserDuelStats, uselist=False, cascade="all, delete-orphan", passive_deletes=True, back_populates="user"
     )
 
@@ -175,6 +175,12 @@ class User(Base):
         if timed_out is not False:
             raise ValueError("Only `False` may be assigned to User.timed_out")
         self.timeout_end = None
+
+    @property
+    def duel_stats(self):
+        if self._duel_stats is None:
+            self._duel_stats = UserDuelStats()
+        return self._duel_stats
 
     def can_afford(self, points_to_spend):
         return self.points >= points_to_spend

--- a/pajbot/modules/duel.py
+++ b/pajbot/modules/duel.py
@@ -8,7 +8,6 @@ from pajbot.managers.db import DBManager
 from pajbot.managers.handler import HandlerManager
 from pajbot.models.command import Command
 from pajbot.models.command import CommandExample
-from pajbot.models.duel import UserDuelStats
 from pajbot.models.user import User
 from pajbot.modules import BaseModule
 from pajbot.modules import ModuleSetting
@@ -266,8 +265,9 @@ class DuelModule(BaseModule):
             winner.points += duel_price
             winner.points += winning_pot
 
-            UserDuelStats.for_user(db_session, winner).won(winning_pot)
-            UserDuelStats.for_user(db_session, loser).lost(duel_price)
+            # Persist duel statistics
+            winner.duel_stats.won(winning_pot)
+            winner.duel_stats.lost(duel_price)
 
             arguments = {
                 "winner": winner.name,


### PR DESCRIPTION
Note: This continues the changes by #518
Here are only the changes meant for this PR: https://github.com/pajbot/pajbot/pull/519/files/f494569a7cebe11760df54776aa5542694522f78..76209e4e06fdfdf859279f3c96007cad8578d2c4

A crash was caused on `db_session.commit()` when `UserDuelStats.for_user` was used with a `db_session` that the also-passed-in `user` did not belong to.

Replaced `UserDuelStats.for_user` with a `@property` on `User` that initializes default duel stats if needed. The duel stats are comitted/added alongside the user through the SQLAlchemy relationship. (This is also how the `UserDuelStats.user_id` get assigned - via `self._duel_stats = UserDuelStats()`)

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
