### PR TITLE
Fix: Return tokens and points on failed command

### DIFF
--- a/pajbot/models/user.py
+++ b/pajbot/models/user.py
@@ -190,8 +190,11 @@ class User(Base):
 
     @contextmanager
     def spend_currency_context(self, points, tokens):
-        with self._spend_currency_context(points, "points"), self._spend_currency_context(tokens, "tokens"):
-            yield
+        try:
+            with self._spend_currency_context(points, "points"), self._spend_currency_context(tokens, "tokens"):
+                yield
+        except FailedCommand:
+            pass
 
     @contextmanager
     def _spend_currency_context(self, amount, currency):
@@ -200,10 +203,6 @@ class User(Base):
 
         try:
             yield
-        except FailedCommand:
-            log.debug(f"Returning {amount} {currency} to {self}")
-            setattr(self, currency, getattr(self, currency) + amount)
-            # no raise
         except:
             log.debug(f"Returning {amount} {currency} to {self}")
             setattr(self, currency, getattr(self, currency) + amount)


### PR DESCRIPTION
I introduced a bug that would make it so only tokens were returned on failed commands



Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
