### PR TITLE
Only show duel stats if the user has dueled before

### DIFF
--- a/templates/user.html
+++ b/templates/user.html
@@ -77,7 +77,7 @@
             </tbody>
         </table>
 
-        {% if user.duel_stats %}
+        {% if user.duel_stats.duels_total > 0 %}
         <h3>Duel stats</h3>
         <table class="ui very basic table celled">
             <tbody>


### PR DESCRIPTION
duel_stats used to be None if the user hadn't dueled before, now we check duels_total instead

Fixes #523



Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
