### PR TITLE
Raffle module: Simplify winner picking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,11 @@ Remember to bring your dependencies up to date with `pip install -r requirements
 - Minor: Added setting to adjust points tax for the duel module
 - Minor: Link checker module now prints far less debug info about itself.
 - Minor: Added possibility to modify command token cost using `--tokens-cost` in `!add command`/`!edit command` commands.
+- Minor: Added two pluralization cases for when only a single user wins a multi-raffle.
 - Bugfix: Errors in the main thread no longer exit the bot (#443)
 - Bugfix: Several places in the bot and Web UI now correctly show the user display name instead of login name
 - Bugfix: Removed unfinished "email tag" API.
 - Bugfix: If the bot is restarted during an active HSBet game, bets will no longer be lost.
-- Bugfix: Added two pluralization cases for when only a single user wins a multi-raffle.
 
 ## v1.37
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Remember to bring your dependencies up to date with `pip install -r requirements
 - Bugfix: Several places in the bot and Web UI now correctly show the user display name instead of login name
 - Bugfix: Removed unfinished "email tag" API.
 - Bugfix: If the bot is restarted during an active HSBet game, bets will no longer be lost.
+- Bugfix: Added two pluralization cases for when only a single user wins a multi-raffle.
 
 ## v1.37
 


### PR DESCRIPTION
Replaces brute force by some simple-ish math, the effect on the user/output should be zero, but should make it clearer what's going on.

Also includes a fix to pluralize raffle winners correctly if only one user wins in a multiraffle.

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
