### PR TITLE
Fix subscriber update module not setting subscriber status in the DB correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,6 @@ Remember to bring your dependencies up to date with `pip install -r requirements
 - Bugfix: Several places in the bot and Web UI now correctly show the user display name instead of login name
 - Bugfix: Removed unfinished "email tag" API.
 - Bugfix: If the bot is restarted during an active HSBet game, bets will no longer be lost.
-- Bugfix: Fixed a bug with the automatic subscriber update that made most subscribers incorrectly be marked as non-subscribers
 
 ## v1.37
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Remember to bring your dependencies up to date with `pip install -r requirements
 - Bugfix: Several places in the bot and Web UI now correctly show the user display name instead of login name
 - Bugfix: Removed unfinished "email tag" API.
 - Bugfix: If the bot is restarted during an active HSBet game, bets will no longer be lost.
+- Bugfix: Fixed a bug with the automatic subscriber update that made most subscribers incorrectly be marked as non-subscribers
 
 ## v1.37
 


### PR DESCRIPTION
The problem was caused because the big SQL statement was executed for each user/subscriber individually, and so only the last subscriber in the list was marked properly in the DB. Switched to a temporary table that is dropped on commit.



Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
