### PR TITLE
Add automatic refresh of user's moderator status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Remember to bring your dependencies up to date with `pip install -r requirements
 - Minor: Added possibility to modify command token cost using `--tokens-cost` in `!add command`/`!edit command` commands.
 - Minor: Added two pluralization cases for when only a single user wins a multi-raffle.
 - Minor: Added logging output for notices received from the SQL server.
+- Minor: The bot automatically now additionally refreshes who is a moderator and who isn't (This data was previously only updated when the user typed a message). A `!reload moderators` command has been added to trigger this update manually.
 - Bugfix: Errors in the main thread no longer exit the bot (#443)
 - Bugfix: Several places in the bot and Web UI now correctly show the user display name instead of login name
 - Bugfix: Removed unfinished "email tag" API.

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -779,6 +779,16 @@ class Bot:
 
             self.parse_message(event.arguments[0], source, event, tags=tags)
 
+    def on_pubnotice(self, chatconn, event):
+        tags = {tag["key"]: tag["value"] if tag["value"] is not None else "" for tag in event.tags}
+        HandlerManager.trigger(
+            "on_pubnotice",
+            stop_on_false=False,
+            channel=event.target[1:],
+            msg_id=tags["msg-id"],
+            message=event.arguments[0],
+        )
+
     @time_method
     def commit_all(self):
         for key, manager in self.commitable.items():

--- a/pajbot/managers/handler.py
+++ b/pajbot/managers/handler.py
@@ -22,6 +22,9 @@ class HandlerManager:
         # on_usernotice(source, message, tags)
         HandlerManager.create_handler("on_usernotice")
 
+        # on_pubnotice(channel, msg_id, message)
+        HandlerManager.create_handler("on_pubnotice")
+
         # on_commit()
         HandlerManager.create_handler("on_commit")
 

--- a/pajbot/modules/__init__.py
+++ b/pajbot/modules/__init__.py
@@ -39,6 +39,7 @@ from pajbot.modules.linktracker import LinkTrackerModule
 from pajbot.modules.math import MathModule
 from pajbot.modules.maxmsglength import MaxMsgLengthModule
 from pajbot.modules.casechecker import CaseCheckerModule
+from pajbot.modules.moderators_refresh import ModeratorsRefreshModule
 from pajbot.modules.paidsubmode import PaidSubmodeModule
 from pajbot.modules.paidtimeout import PaidTimeoutModule
 from pajbot.modules.paiduntimeout import PaidUntimeoutModule
@@ -102,6 +103,7 @@ available_modules = [
     LinkTrackerModule,
     MathModule,
     MaxMsgLengthModule,
+    ModeratorsRefreshModule,
     CaseCheckerModule,
     EmoteTimeoutModule,
     PaidSubmodeModule,

--- a/pajbot/modules/moderators_refresh.py
+++ b/pajbot/modules/moderators_refresh.py
@@ -32,7 +32,7 @@ class ModeratorsRefreshModule(BaseModule):
         # TODO if you wanted to improve this: Provide the user with feedback
         #   whether the update succeeded, and if yes, how many users were updated
         bot.whisper(source, "Reloading list of moderators...")
-        bot.action_queue.submit(self._update_moderators)
+        self._update_moderators()
 
     def _update_moderators(self):
         self.bot.privmsg("/mods")
@@ -138,9 +138,9 @@ WHERE
 
         HandlerManager.add_handler("on_pubnotice", self._on_pubnotice)
 
-        # every 10 minutes, add the chatters update to the action queue
+        # every 10 minutes, send the /mods command (response is received via _on_pubnotice)
         self.scheduled_job = ScheduleManager.execute_every(
-            self.UPDATE_INTERVAL * 60, lambda: self.bot.action_queue.submit(self._update_moderators)
+            self.UPDATE_INTERVAL * 60, lambda: self.bot.execute_now(self._update_moderators)
         )
 
     def disable(self, bot):

--- a/pajbot/modules/moderators_refresh.py
+++ b/pajbot/modules/moderators_refresh.py
@@ -110,6 +110,8 @@ WHERE
                 )
             )
 
+        log.info(f"Successfully updated {len(moderator_basics)} moderators")
+
     def load_commands(self, **options):
         self.commands["reload"] = Command.multiaction_command(
             command="reload",

--- a/pajbot/modules/moderators_refresh.py
+++ b/pajbot/modules/moderators_refresh.py
@@ -1,0 +1,153 @@
+import logging
+
+from datetime import timedelta
+from sqlalchemy import text
+
+from pajbot.managers.db import DBManager
+from pajbot.managers.handler import HandlerManager
+from pajbot.managers.schedule import ScheduleManager
+from pajbot.models.command import Command, CommandExample
+from pajbot.modules import BaseModule, ModuleType
+from pajbot.utils import time_method
+
+log = logging.getLogger(__name__)
+
+
+class ModeratorsRefreshModule(BaseModule):
+    ID = __name__.split(".")[-1]
+    NAME = "Moderators refresh"
+    DESCRIPTION = "Regularly updates data about who is moderator"
+    ENABLED_DEFAULT = True
+    HIDDEN = True
+    MODULE_TYPE = ModuleType.TYPE_ALWAYS_ENABLED
+    CATEGORY = "Internal"
+
+    UPDATE_INTERVAL = 10  # minutes
+
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.scheduled_job = None
+
+    def update_moderators_cmd(self, bot, source, **rest):
+        # TODO if you wanted to improve this: Provide the user with feedback
+        #   whether the update succeeded, and if yes, how many users were updated
+        bot.whisper(source, "Reloading list of moderators...")
+        bot.action_queue.submit(self._update_moderators)
+
+    def _update_moderators(self):
+        self.bot.privmsg("/mods")
+
+    @staticmethod
+    def _parse_pubnotice_for_mods(msg_id, message):
+        if msg_id == "no_mods":
+            return []
+
+        if msg_id == "room_mods":
+            if message.startswith("The moderators of this channel are: "):
+                message = message[36:]  # 36 = length of the above "prefix"
+                return message.split(", ")
+            else:
+                log.warning(
+                    f"Received room_mods NOTICE message, but actual message did not begin with expected prefix. Message was: {message}"
+                )
+
+        return None
+
+    def _on_pubnotice(self, channel, msg_id, message):
+        if channel != self.bot.streamer:
+            return
+
+        moderator_logins = self._parse_pubnotice_for_mods(msg_id, message)
+        if moderator_logins is not None:
+            self.bot.action_queue.submit(self._process_moderator_logins, moderator_logins)
+
+    @time_method
+    def _process_moderator_logins(self, moderator_logins):
+        # Called on the action queue thread, to resolve the logins to user IDs
+        moderator_basics = self.bot.twitch_helix_api.bulk_get_user_basics_by_login(moderator_logins)
+
+        # filter out invalid/deleted/etc. users
+        moderator_basics = [e for e in moderator_basics if e is not None]
+
+        with DBManager.create_session_scope() as db_session:
+            db_session.execute(
+                text(
+                    """
+CREATE TEMPORARY TABLE moderators(
+    id TEXT PRIMARY KEY NOT NULL,
+    login TEXT NOT NULL,
+    name TEXT NOT NULL
+)
+ON COMMIT DROP"""
+                )
+            )
+
+            db_session.execute(
+                text("INSERT INTO moderators(id, login, name) VALUES (:id, :login, :name)"),
+                [basics.jsonify() for basics in moderator_basics],
+            )
+
+            # hint to understand this query: "excluded" is a PostgreSQL keyword that referers
+            # to the data we tried to insert but failed (so excluded.login would be equal to :login
+            # if we only had one value for :login)
+            db_session.execute(
+                text(
+                    """
+WITH updated_users AS (
+    INSERT INTO "user"(id, login, name, moderator)
+        SELECT id, login, name, TRUE FROM moderators
+    ON CONFLICT (id) DO UPDATE SET
+        login = excluded.login,
+        name = excluded.name,
+        moderator = TRUE
+    RETURNING id
+)
+UPDATE "user"
+SET
+    moderator = FALSE
+WHERE
+    id NOT IN (SELECT * FROM updated_users) AND
+    moderator IS TRUE"""
+                )
+            )
+
+    def load_commands(self, **options):
+        self.commands["reload"] = Command.multiaction_command(
+            command="reload",
+            commands={
+                "moderators": Command.raw_command(
+                    self.update_moderators_cmd,
+                    delay_all=120,
+                    delay_user=120,
+                    level=1000,
+                    examples=[
+                        CommandExample(
+                            None,
+                            f"Reload who is a Twitch channel moderator",
+                            chat=f"user:!reload moderators\nbot>user: Reloading moderator status...",
+                        ).parse()
+                    ],
+                )
+            },
+        )
+
+    def enable(self, bot):
+        # Web interface, nothing to do
+        if not bot:
+            return
+
+        HandlerManager.add_handler("on_pubnotice", self._on_pubnotice)
+
+        # every 10 minutes, add the chatters update to the action queue
+        self.scheduled_job = ScheduleManager.execute_every(
+            self.UPDATE_INTERVAL * 60, lambda: self.bot.action_queue.submit(self._update_moderators)
+        )
+
+    def disable(self, bot):
+        # Web interface, nothing to do
+        if not bot:
+            return
+
+        HandlerManager.remove_handler("on_pubnotice", self._on_pubnotice)
+
+        self.scheduled_job.remove()

--- a/pajbot/modules/moderators_refresh.py
+++ b/pajbot/modules/moderators_refresh.py
@@ -1,6 +1,5 @@
 import logging
 
-from datetime import timedelta
 from sqlalchemy import text
 
 from pajbot.managers.db import DBManager


### PR DESCRIPTION
I decided to use `/mods`.


Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
