### PR TITLE
Added some migration notes, and limit amount of tokens that can be migrated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Remember to bring your dependencies up to date with `pip install -r requirements
   sudo -u pajbot ./scripts/redis-dump.py streamer > redis_dump_streamer.bin
   ```
 
+  When migrating a bot you probably want to either disable the chatters microservice entirely, or remove that bot's entry from the chatters `config.json`.
+
 - Feature: Added module to fetch current chatters and update the database back to the bot (was previously [a microservice](https://github.com/pajbot/chatters)). Includes a new `!reload chatters` command.
 - Feature: Added `!reload subscribers` command to force refresh of subscriber status in the DB.
 - Minor: Added `?user_input=true` optional parameter to `/api/v1/users/:login` endpoint to query for usernames more fuzzily.

--- a/pajbot/migration_revisions/db/0003_create_or_update_foreign_key_constraints.py
+++ b/pajbot/migration_revisions/db/0003_create_or_update_foreign_key_constraints.py
@@ -5,7 +5,13 @@ def up(cursor, bot):
     cursor.execute('ALTER TABLE banphrase_data ADD FOREIGN KEY (edited_by) REFERENCES "user"(id) ON DELETE SET NULL')
 
     # command_data
+    # In case you run into issues where this foreign key cannot be added because a referenced user does not exist, you can run the following query:
+    #   UPDATE command_data SET added_by = NULL WHERE NOT EXISTS( SELECT 1 FROM "user" WHERE command_data.added_by = "user".id  );
+    # It will update all rows where added_by references a non-exitant user and set the added_by value to NULL
     cursor.execute('ALTER TABLE command_data ADD FOREIGN KEY (added_by) REFERENCES "user"(id) ON DELETE SET NULL')
+    # In case you run into issues where this foreign key cannot be added because a referenced user does not exist, you can run the following query:
+    #   UPDATE command_data SET edited_by = NULL WHERE NOT EXISTS( SELECT 1 FROM "user" WHERE command_data.edited_by = "user".id  );
+    # It will update all rows where edited_by references a non-exitant user and set the added_by value to NULL
     cursor.execute('ALTER TABLE command_data ADD FOREIGN KEY (edited_by) REFERENCES "user"(id) ON DELETE SET NULL')
 
     # pleblist_song
@@ -19,6 +25,9 @@ def up(cursor, bot):
     cursor.execute('ALTER TABLE prediction_run_entry ADD FOREIGN KEY (user_id) REFERENCES "user"(id) ON DELETE CASCADE')
 
     # roulette
+    # In case you run into issues where this foreign key cannot be added because a referenced user does not exist, you can run the following query:
+    #   DELETE FROM roulette WHERE NOT EXISTS( SELECT 1 FROM "user" WHERE roulette.user_id = "user".id  );
+    # It will delete all roulette stats for users that don't exist
     cursor.execute('ALTER TABLE roulette ADD FOREIGN KEY (user_id) REFERENCES "user"(id) ON DELETE CASCADE')
 
     # stream_chunk

--- a/pajbot/migration_revisions/db/0004_unify_user_model.py
+++ b/pajbot/migration_revisions/db/0004_unify_user_model.py
@@ -63,6 +63,8 @@ def up(cursor, bot):
         if tokens is None:
             # invalid amount in redis, skip
             continue
+        if tokens > 50:
+            tokens = 50
         cursor.execute('UPDATE "user" SET tokens = %s WHERE login = %s', (tokens, login))
 
     # new: last_seen


### PR DESCRIPTION
Some manual queries were added in migration 3 in case foreign keys weren't able to be added properly.
Tokens migrated are limited to 50.
Add a changelog entry mentioning the chatters microservice, and how you should handle that in the migration.

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
