### PR TITLE
Fix long-running transaction created by web process and link checker module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Remember to bring your dependencies up to date with `pip install -r requirements
 - Bugfix: Several places in the bot and Web UI now correctly show the user display name instead of login name
 - Bugfix: Removed unfinished "email tag" API.
 - Bugfix: If the bot is restarted during an active HSBet game, bets will no longer be lost.
+- Bugfix: Web process no longer creates a super long-running database transaction that was never closed.
 
 ## v1.37
 

--- a/pajbot/modules/linkchecker.py
+++ b/pajbot/modules/linkchecker.py
@@ -193,6 +193,9 @@ class LinkCheckerModule(BaseModule):
             self.safe_browsing_api = None
 
     def enable(self, bot):
+        if not bot:
+            return
+
         HandlerManager.add_handler("on_message", self.on_message, priority=100)
         HandlerManager.add_handler("on_commit", self.on_commit)
 
@@ -210,6 +213,9 @@ class LinkCheckerModule(BaseModule):
             self.whitelisted_links.append(link)
 
     def disable(self, bot):
+        if not bot:
+            return
+
         pajbot.managers.handler.HandlerManager.remove_handler("on_message", self.on_message)
         pajbot.managers.handler.HandlerManager.remove_handler("on_commit", self.on_commit)
 


### PR DESCRIPTION
This place was `enable()`-ing the link checker module:

https://github.com/pajbot/pajbot/blob/56f4cfcde83624741e0eeb4672115e486bec6ced/pajbot/web/__init__.py#L98

And never disabling it, so the transaction would run forever. (3+ weeks in my case)


Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
