### PR TITLE
Handle non-existant emotes tag

### DIFF
--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -638,6 +638,10 @@ class Bot:
         msg_lower = message.lower()
 
         emote_tag = tags["emotes"]
+        if emote_tag is None:
+            # Temporary debugging code to investigate issue #579
+            log.info("Got a message with emote_tag=None, event is: %s", event)
+
         msg_id = tags.get("id", None)  # None on whispers!
 
         if not whisper and event.target == self.channel:

--- a/pajbot/managers/emote.py
+++ b/pajbot/managers/emote.py
@@ -179,7 +179,7 @@ class EmoteManager:
 
     @staticmethod
     def parse_twitch_emotes_tag(tag, message):
-        if len(tag) <= 0:
+        if tag is None or len(tag) <= 0:
             return []
 
         emote_instances = []


### PR DESCRIPTION
Sometimes the emotes tag just isn't sent along with a message. we need
to check if the tag received in the `parse_twitch_emotes_tag` function
is None before starting to process it

I don't have an example message of this, but it did happen. idk how :man_shrugging: 

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
