### PR TITLE
Fix an exception when attempting to refresh app access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Remember to bring your dependencies up to date with `pip install -r requirements
 - Bugfix: Removed unfinished "email tag" API.
 - Bugfix: If the bot is restarted during an active HSBet game, bets will no longer be lost.
 - Bugfix: Web process no longer creates a super long-running database transaction that was never closed.
+- Bugfix: Fixed a crash when an app access token expired and needed to be refreshed.
 
 ## v1.37
 

--- a/pajbot/apiwrappers/authentication/access_token.py
+++ b/pajbot/apiwrappers/authentication/access_token.py
@@ -110,7 +110,7 @@ class AccessToken(ABC):
             expires_in=expires_in,
             token_type=response["token_type"],
             refresh_token=response.get("refresh_token", None),
-            scope=response.get("scope", None),
+            scope=response.get("scope", []),
         )
 
     @abstractmethod


### PR DESCRIPTION
We were then trying to `" ".join(scope)`, which was None on all App Access Tokens.

If you are having trouble with existing tokens, try redis-cli: `DEL authentication:app-access-<ClientID>:[]`

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
