### PR TITLE
Change time_since function to only use plural when the number is equal to 1.

### DIFF
--- a/pajbot/utils/time_since.py
+++ b/pajbot/utils/time_since.py
@@ -22,7 +22,7 @@ def time_since(t1, t2, time_format="long"):
     while i < 2 and j < 6:
         if num[j] > 0:
             if time_format == "long":
-                time_arr.append(f"{num[j]:g} {num_dict[j]}{'s' if num[j] > 1 else ''}")
+                time_arr.append(f"{num[j]:g} {num_dict[j]}{'s' if num[j] != 1 else ''}")
             else:
                 time_arr.append(f"{num[j]}{num_dict[j]}")
             i += 1


### PR DESCRIPTION
Right now anything below 1, such as 0.8 seconds prints as 0.8 second in chat. This doesn't make sense, and propose instead only use the singular when it is exactly equal to 1.



Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
