### PR TITLE
Add jitter to refresh interval for points_rank materialized view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unversioned
 
+- Minor: The regular refresh of the points_rank and num_lines_rank is now randomly jittered by ±30s to reduce CPU spikes when multiple instances are restarted at the same time
 - Bugfix: Fixed an exception and the message not being handled whenever a message contained an emote modified via the "Channel Points" Twitch feature.
 - Bugfix: Fixed an exception whenever the result of a command was being checked by the massping module.
+- Bugfix: Fixed points_rank and num_lines_rank never refreshing automatically.
 
 ## v1.38
 

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -73,6 +73,8 @@ class Bot:
         self.last_ping = utils.now()
         self.last_pong = utils.now()
 
+        ScheduleManager.init()
+
         DBManager.init(self.config["main"]["db"])
 
         # redis
@@ -172,7 +174,6 @@ class Bot:
         self.stream_manager = StreamManager(self)
 
         StreamHelper.init_bot(self, self.stream_manager)
-        ScheduleManager.init()
 
         self.decks = DeckManager()
         self.banphrase_manager = BanphraseManager(self).load()

--- a/pajbot/managers/schedule.py
+++ b/pajbot/managers/schedule.py
@@ -59,12 +59,12 @@ class ScheduleManager:
         return ScheduledJob(job)
 
     @staticmethod
-    def execute_every(interval, method, args=[], kwargs={}, scheduler=None):
+    def execute_every(interval, method, args=[], kwargs={}, scheduler=None, jitter=None):
         if scheduler is None:
             scheduler = ScheduleManager.base_scheduler
 
         if scheduler is None:
             return ScheduledJob(None)
 
-        job = scheduler.add_job(method, "interval", seconds=interval, args=args, kwargs=kwargs)
+        job = scheduler.add_job(method, "interval", seconds=interval, args=args, kwargs=kwargs, jitter=jitter)
         return ScheduledJob(job)


### PR DESCRIPTION
Also: ScheduleManager init had to be moved up in the init sequence, otherwise the initial run and the refresh would not fire

Fixes #578 


Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
