### PR TITLE
Fail-fast if ScheduleManager is used before init()

### DIFF
--- a/pajbot/managers/schedule.py
+++ b/pajbot/managers/schedule.py
@@ -40,7 +40,7 @@ class ScheduleManager:
             scheduler = ScheduleManager.base_scheduler
 
         if scheduler is None:
-            return ScheduledJob(None)
+            raise ValueError("No scheduler available")
 
         job = scheduler.add_job(method, "date", run_date=utils.now(), args=args, kwargs=kwargs)
         return ScheduledJob(job)
@@ -51,7 +51,7 @@ class ScheduleManager:
             scheduler = ScheduleManager.base_scheduler
 
         if scheduler is None:
-            return ScheduledJob(None)
+            raise ValueError("No scheduler available")
 
         job = scheduler.add_job(
             method, "date", run_date=utils.now() + datetime.timedelta(seconds=delay), args=args, kwargs=kwargs
@@ -64,7 +64,7 @@ class ScheduleManager:
             scheduler = ScheduleManager.base_scheduler
 
         if scheduler is None:
-            return ScheduledJob(None)
+            raise ValueError("No scheduler available")
 
         job = scheduler.add_job(method, "interval", seconds=interval, args=args, kwargs=kwargs)
         return ScheduledJob(job)

--- a/pajbot/modules/hsbet.py
+++ b/pajbot/modules/hsbet.py
@@ -71,11 +71,6 @@ class HSBetModule(BaseModule):
         self.first_fetch = True
         self.last_game = None
 
-        self.poll_job = ScheduleManager.execute_every(15, self.poll_trackobot)
-        self.poll_job.pause()
-        self.reminder_job = ScheduleManager.execute_every(1, self.reminder_bet)
-        self.reminder_job.pause()
-
     def get_current_game(self, db_session, with_bets=False, with_users=False):
         query = db_session.query(HSBetGame).filter(HSBetGame.is_running)
 
@@ -347,12 +342,15 @@ class HSBetModule(BaseModule):
 
     def enable(self, bot):
         if bot:
-            self.poll_job.resume()
-            self.reminder_job.resume()
+            self.poll_job = ScheduleManager.execute_every(15, self.poll_trackobot)
+            self.reminder_job = ScheduleManager.execute_every(1, self.reminder_bet)
 
     def disable(self, bot):
         if bot:
-            self.poll_job.pause()
-            self.reminder_job.pause()
+            self.poll_job.remove()
+            self.poll_job = None
+            self.reminder_job.remove()
+            self.reminder_job = None
+
             self.first_fetch = True
             self.last_game = None

--- a/pajbot/modules/trivia.py
+++ b/pajbot/modules/trivia.py
@@ -62,8 +62,7 @@ class TriviaModule(BaseModule):
     def __init__(self, bot):
         super().__init__(bot)
 
-        self.job = ScheduleManager.execute_every(1, self.poll_trivia)
-        self.job.pause()
+        self.job = None
 
         self.trivia_running = False
         self.last_question = None
@@ -164,7 +163,7 @@ class TriviaModule(BaseModule):
             return
 
         self.trivia_running = True
-        self.job.resume()
+        self.job = ScheduleManager.execute_every(1, self.poll_trivia)
 
         try:
             self.point_bounty = int(message)
@@ -187,7 +186,8 @@ class TriviaModule(BaseModule):
             bot.safe_me(f"{source}, no trivia is active right now")
             return
 
-        self.job.pause()
+        self.job.remove()
+        self.job = None
         self.trivia_running = False
         self.step_end()
 


### PR DESCRIPTION
This led to the an issue fixed by #590 (the issue that the ranks refresh every 5 minutes wasn't working)

Note that if you try this PR out on its own, the bot will not start, because the fail-fast "detects" the bug fixed by #590. If you merge #590 first, and then this PR, then the bot will start.

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
