### PR TITLE
Feed points rate gain info from settings of chatters refresh module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Minor: The regular refresh of the points_rank and num_lines_rank is now randomly jittered by ±30s to reduce CPU spikes when multiple instances are restarted at the same time
 - Minor: Added setting to configure bypass level to "Link Checker" module.
 - Minor: The bot now uses the BTTV v3 API, which should fix some cases where the bot considered more emotes to be enabled than were actually supposed to be enabled.
+- Minor: The points gain rate information at the top of the points page is now dynamically updated based upon your settings for the "Chatters Refresh" module.
 - Bugfix: Fixed an exception and the message not being handled whenever a message contained an emote modified via the "Channel Points" Twitch feature.
 - Bugfix: Fixed an exception whenever the result of a command was being checked by the massping module.
 - Bugfix: Fixed a lot of log-spam and the subscribers refresh not working when the bot was running in its own channel. Re-authorize via `/bot_login` after this update if you were affected by this issue before.

--- a/pajbot/modules/base.py
+++ b/pajbot/modules/base.py
@@ -161,6 +161,15 @@ class BaseModule:
 
         return settings
 
+    @classmethod
+    def is_enabled(cls):
+        with DBManager.create_session_scope() as db_session:
+            db_module = db_session.query(Module).filter_by(id=cls.ID).one_or_none()
+            if db_module is None:
+                return cls.ENABLED_DEFAULT
+            else:
+                return db_module.enabled
+
     def load_commands(self, **options):
         pass
 

--- a/pajbot/web/common/filters.py
+++ b/pajbot/web/common/filters.py
@@ -75,3 +75,11 @@ def init(app):
         m = s % 3600 / 60
         s = s % 60
         return "%dh%02dm%02ds" % (h, m, s)
+
+    @app.template_filter("with_unit")
+    def with_unit(value, unit, plural_suffix="s"):
+        """with_unit ≙ value_with_pluralized_unit"""
+        if value == 1:
+            return f"{value} {unit}"  # e.g. 1 point
+        else:
+            return f"{value} {unit}{plural_suffix}"  # e.g. 2 points

--- a/pajbot/web/routes/base/playsounds.py
+++ b/pajbot/web/routes/base/playsounds.py
@@ -1,7 +1,6 @@
 from flask import render_template
 
 from pajbot.managers.db import DBManager
-from pajbot.models.module import Module
 from pajbot.models.playsound import Playsound
 from pajbot.modules import PlaysoundModule
 

--- a/pajbot/web/routes/base/playsounds.py
+++ b/pajbot/web/routes/base/playsounds.py
@@ -11,15 +11,10 @@ def init(app):
     def user_playsounds():
         with DBManager.create_session_scope() as session:
             playsounds = session.query(Playsound).filter(Playsound.enabled).order_by(Playsound.name).all()
-            playsound_module = session.query(Module).filter(Module.id == PlaysoundModule.ID).one_or_none()
-
-            enabled = False
-            if playsound_module is not None:
-                enabled = playsound_module.enabled
 
             return render_template(
                 "playsounds.html",
                 playsounds=playsounds,
                 module_settings=PlaysoundModule.module_settings(),
-                playsounds_enabled=enabled,
+                playsounds_enabled=PlaysoundModule.is_enabled(),
             )

--- a/pajbot/web/routes/base/points.py
+++ b/pajbot/web/routes/base/points.py
@@ -6,8 +6,10 @@ from flask import render_template
 from sqlalchemy import text
 
 from pajbot.managers.db import DBManager
+from pajbot.models.module import Module
 from pajbot.models.user import User
 from pajbot.models.webcontent import WebContent
+from pajbot.modules import ChattersRefreshModule
 
 log = logging.getLogger(__name__)
 
@@ -43,4 +45,15 @@ def init(app):
                 )
             )
 
-            return render_template("points.html", top_30_users=rankings, custom_content=custom_content)
+            chatters_refresh_enabled = ChattersRefreshModule.is_enabled()
+            chatters_refresh_settings = ChattersRefreshModule.module_settings()
+            chatters_refresh_interval = ChattersRefreshModule.UPDATE_INTERVAL
+
+            return render_template(
+                "points.html",
+                top_30_users=rankings,
+                custom_content=custom_content,
+                chatters_refresh_enabled=chatters_refresh_enabled,
+                chatters_refresh_settings=chatters_refresh_settings,
+                chatters_refresh_interval=chatters_refresh_interval,
+            )

--- a/pajbot/web/routes/base/points.py
+++ b/pajbot/web/routes/base/points.py
@@ -6,7 +6,6 @@ from flask import render_template
 from sqlalchemy import text
 
 from pajbot.managers.db import DBManager
-from pajbot.models.module import Module
 from pajbot.models.user import User
 from pajbot.models.webcontent import WebContent
 from pajbot.modules import ChattersRefreshModule

--- a/templates/points.html
+++ b/templates/points.html
@@ -16,7 +16,7 @@
     </form>
     <div class="ui response hidden"></div>
 </div>
-<h2>Points</h2>
+<h2>Points Leaderboard</h2>
 <div id="top_users">
     <table class="ui very basic table collapsing">
         <thead>

--- a/templates/points.html
+++ b/templates/points.html
@@ -2,9 +2,15 @@
 {% set active_page = 'points' %}
 {% block title %}Points{% endblock %}
 {% block body %}
-<h2>Description</h2>
-<p><i class="large icon pin"></i>Subscribers gain <strong>5 points per 5 minutes</strong> while watching the stream.</p>
-<p><i class="large icon pin"></i>Non-subscribers gain <strong>1 point per 5 minutes</strong> while watching the stream.</p>
+{% if chatters_refresh_enabled and (chatters_refresh_settings["base_points_sub"] > 0 or chatters_refresh_settings["base_points_pleb"] > 0) %}
+    <h2>Description</h2>
+    {% if chatters_refresh_settings["base_points_sub"] > 0 %}
+        <p><i class="large icon pin"></i>Subscribers gain <strong>{{ chatters_refresh_settings["base_points_sub"]|with_unit("point") }} every {{ chatters_refresh_interval|with_unit("minute") }}</strong> of watching the stream.</p>
+    {% endif %}
+    {% if chatters_refresh_settings["base_points_pleb"] > 0 %}
+        <p><i class="large icon pin"></i>Non-subscribers gain <strong>{{ chatters_refresh_settings["base_points_pleb"]|with_unit("point") }} every {{ chatters_refresh_interval|with_unit("minute") }}</strong> of watching the stream.</p>
+    {% endif %}
+{% endif %}
 {{ custom_content }}
 <h2>Check your own Points and Rank</h2>
 <div id="check_points" class="ui form">

--- a/templates/points.html
+++ b/templates/points.html
@@ -4,11 +4,28 @@
 {% block body %}
 {% if chatters_refresh_enabled and (chatters_refresh_settings["base_points_sub"] > 0 or chatters_refresh_settings["base_points_pleb"] > 0) %}
     <h2>Description</h2>
+
+    {% set offline_chat_multiplier = chatters_refresh_settings["offline_chat_multiplier"] / 100 %}
+    {% set offline_points_sub = (chatters_refresh_settings["base_points_sub"] * offline_chat_multiplier)|round|int %}
+    {% set offline_points_pleb = (chatters_refresh_settings["base_points_pleb"] * offline_chat_multiplier)|round|int %}
+
     {% if chatters_refresh_settings["base_points_sub"] > 0 %}
-        <p><i class="large icon pin"></i>Subscribers gain <strong>{{ chatters_refresh_settings["base_points_sub"]|with_unit("point") }} every {{ chatters_refresh_interval|with_unit("minute") }}</strong> of watching the stream.</p>
+        <p>
+            <i class="large icon pin"></i>Subscribers gain <strong>{{ chatters_refresh_settings["base_points_sub"]|with_unit("point") }} every {{ chatters_refresh_interval|with_unit("minute") }}</strong> of watching the stream
+                {%- if offline_points_sub > 0 -%}
+                    , and {{ offline_points_sub|with_unit("point") }} for every {{ chatters_refresh_interval|with_unit("minute") }} of being in offline chat
+                {%- endif -%}
+            .
+        </p>
     {% endif %}
     {% if chatters_refresh_settings["base_points_pleb"] > 0 %}
-        <p><i class="large icon pin"></i>Non-subscribers gain <strong>{{ chatters_refresh_settings["base_points_pleb"]|with_unit("point") }} every {{ chatters_refresh_interval|with_unit("minute") }}</strong> of watching the stream.</p>
+        <p>
+            <i class="large icon pin"></i>Non-Subscribers gain <strong>{{ chatters_refresh_settings["base_points_pleb"]|with_unit("point") }} every {{ chatters_refresh_interval|with_unit("minute") }}</strong> of watching the stream
+                {%- if offline_points_pleb > 0 -%}
+                    , and {{ offline_points_pleb|with_unit("point") }} for every {{ chatters_refresh_interval|with_unit("minute") }} of being in offline chat
+                {%- endif -%}
+            .
+        </p>
     {% endif %}
 {% endif %}
 {{ custom_content }}


### PR DESCRIPTION
Fixes #581 

Screenshots:

sub = 10, pleb = 5, offline rate = 10%
![image](https://user-images.githubusercontent.com/1629196/67436102-ea643200-f5ed-11e9-9c5c-5ae6c5250e59.png)

sub = 10, pleb = 5, offline rate = 0%
![image](https://user-images.githubusercontent.com/1629196/67436119-f223d680-f5ed-11e9-9b11-9c358f662c1b.png)

chatters refresh disabled:
![image](https://user-images.githubusercontent.com/1629196/67436162-0b2c8780-f5ee-11e9-8d44-65e646b5a0ff.png)

sub = 10, pleb = 1, offline rate = 100%
![image](https://user-images.githubusercontent.com/1629196/67436195-24cdcf00-f5ee-11e9-98b2-ca5faf0168a0.png)

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
