### PR TITLE
Remove MySQL-specific error code handling system

### DIFF
--- a/pajbot/managers/db.py
+++ b/pajbot/managers/db.py
@@ -3,40 +3,14 @@ from contextlib import contextmanager
 
 from sqlalchemy import create_engine
 from sqlalchemy import event
-from sqlalchemy import exc
 from sqlalchemy import inspect
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import Pool
 
 Base = declarative_base()
 
 log = logging.getLogger("pajbot")
-
-
-@event.listens_for(Pool, "checkout")
-def check_connection(dbapi_con, _con_record, _con_proxy):
-    """
-    Listener for Pool checkout events that pings every connection before using.
-    Implements pessimistic disconnect handling strategy. See also:
-    http://docs.sqlalchemy.org/en/rel_0_8/core/pooling.html#disconnect-handling-pessimistic
-    """
-
-    cursor = dbapi_con.cursor()
-    try:
-        cursor.execute("SELECT 1")
-    except exc.OperationalError as ex:
-        if ex.args[0] in (
-            2006,  # MySQL server has gone away
-            2013,  # Lost connection to MySQL server during query
-            2055,
-        ):  # Lost connection to MySQL server at '%s', system error: %d
-            # caught by pool, which will retry with a new connection
-            raise exc.DisconnectionError()
-
-        # Raise the normal operational error exception
-        raise
 
 
 class ServerNoticeLogger:


### PR DESCRIPTION
These error codes were only specific to MySQL and should not be relevant for PostgreSQL

I think `pool_pre_ping` already does what we want, in the case of PostgreSQL. `pool_pre_ping` will ensure connections are live (working) before they are checked out and used in the application - To ensure we can transparently reconnect to the database server in the database server unexpectedly restarts without closing its connections first.

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
