### PR TITLE
Convert "raffle_users" from a set to a list before passing it to random.choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Minor: The regular refresh of the points_rank and num_lines_rank is now randomly jittered by ±30s to reduce CPU spikes when multiple instances are restarted at the same time
 - Minor: Added setting to configure bypass level to "Link Checker" module.
 - Minor: The bot now uses the BTTV v3 API, which should fix some cases where the bot considered more emotes to be enabled than were actually supposed to be enabled.
+- Bugfix: Fixed single raffle silently failing when finishing. #610
 - Bugfix: Fixed an exception and the message not being handled whenever a message contained an emote modified via the "Channel Points" Twitch feature.
 - Bugfix: Fixed an exception whenever the result of a command was being checked by the massping module.
 - Bugfix: Fixed a lot of log-spam and the subscribers refresh not working when the bot was running in its own channel. Re-authorize via `/bot_login` after this update if you were affected by this issue before.

--- a/pajbot/modules/raffle.py
+++ b/pajbot/modules/raffle.py
@@ -306,7 +306,7 @@ class RaffleModule(BaseModule):
             return False
 
         with DBManager.create_session_scope() as db_session:
-            winner_id = random.choice(self.raffle_users)
+            winner_id = random.choice(list(self.raffle_users))
             winner = User.find_by_id(db_session, winner_id)
             if winner is None:
                 return False


### PR DESCRIPTION
I believe this was broken before PR #560 - but who uses single raffles?  EleGiggle



Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
