### PR TITLE
Only show git-related information on the website if "dev" config flag is set to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Minor: Added setting to configure bypass level to "Link Checker" module.
 - Minor: The bot now uses the BTTV v3 API, which should fix some cases where the bot considered more emotes to be enabled than were actually supposed to be enabled.
 - Minor: The points gain rate information at the top of the points page is now dynamically updated based upon your settings for the "Chatters Refresh" module.
+- Minor: "dev" config flag is now respected in web, properly omitting any git information in its footer
 - Bugfix: Fixed an exception and the message not being handled whenever a message contained an emote modified via the "Channel Points" Twitch feature.
 - Bugfix: Fixed an exception whenever the result of a command was being checked by the massping module.
 - Bugfix: Fixed a lot of log-spam and the subscribers refresh not working when the bot was running in its own channel. Re-authorize via `/bot_login` after this update if you were affected by this issue before.

--- a/pajbot/web/__init__.py
+++ b/pajbot/web/__init__.py
@@ -96,6 +96,7 @@ def init(args):
     app.bot_commands_list = []
     app.bot_config = config
     app.secret_key = config["web"]["secret_key"]
+    app.bot_dev = "flags" in config and "dev" in config["flags"] and config["flags"]["dev"] == "1"
 
     DBManager.init(config["main"]["db"])
     TimeManager.init_timezone(config["main"].get("timezone", "UTC"))
@@ -115,13 +116,16 @@ def init(args):
     errors.init(app, config)
     pajbot.web.routes.clr.config = config
 
-    version = extend_version_if_possible(VERSION)
+    version = VERSION
+    last_commit = None
 
-    try:
-        last_commit = subprocess.check_output(["git", "log", "-1", "--format=%cd"]).decode("utf8").strip()
-    except:
-        log.exception("Failed to get last_commit, will not show last commit")
-        last_commit = None
+    if app.bot_dev:
+        version = extend_version_if_possible(VERSION)
+
+        try:
+            last_commit = subprocess.check_output(["git", "log", "-1", "--format=%cd"]).decode("utf8").strip()
+        except:
+            log.exception("Failed to get last_commit, will not show last commit")
 
     default_variables = {
         "version": version,


### PR DESCRIPTION

Fixes #614



Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
