### PR TITLE
Better logo and sub badge fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Minor: The bot now uses the BTTV v3 API, which should fix some cases where the bot considered more emotes to be enabled than were actually supposed to be enabled.
 - Minor: The points gain rate information at the top of the points page is now dynamically updated based upon your settings for the "Chatters Refresh" module.
 - Minor: "dev" config flag is now respected in web, properly omitting any git information in its footer
+- Minor: The subscriber badge is now automatically downloaded on web application startup. Which version of the subscriber badge should be downloaded can be configured in config.ini under the `web` section using the `subscriber_badge_version` key. Setting the `subscriber_badge_version` key to `-1` disables the sub badge downloading, in case you want to use a custom subscriber badge (or an old one that you don't want to overwrite)
 - Bugfix: Fixed an exception and the message not being handled whenever a message contained an emote modified via the "Channel Points" Twitch feature.
 - Bugfix: Fixed an exception whenever the result of a command was being checked by the massping module.
 - Bugfix: Fixed a lot of log-spam and the subscribers refresh not working when the bot was running in its own channel. Re-authorize via `/bot_login` after this update if you were affected by this issue before.

--- a/install-docs/debian10/kkonatestbroadcaster.ini
+++ b/install-docs/debian10/kkonatestbroadcaster.ini
@@ -43,6 +43,11 @@ streamer_name = KKonaTestBroadcaster
 domain = bot.kkonatestbroadcaster.tv
 ; this configures hearthstone decks functionality if you have the module enabled
 deck_tab_images = 1
+; this configures which version of the subscriber badge to download for the streamer to be shown on the website next to subscribers
+; the default value is 0 (default sub badge)
+; value of -1 disables the subscriber badge downloading entirely
+; https://badges.twitch.tv/v1/badges/channels/11148817/display?language=en example url to see valid badge versions, replace 11148817 with your twitch user id to see your badges
+subscriber_badge_version = 12
 
 ; streamelements login credentials if you are using pleblist, to get donations info
 ; note that streamelements login with pajbot is dead, since StreamElements removed their OAuth login endpoint.

--- a/pajbot/apiwrappers/twitch/badges.py
+++ b/pajbot/apiwrappers/twitch/badges.py
@@ -81,10 +81,10 @@ class BadgeSets(dict):
 # https://discuss.dev.twitch.tv/t/beta-badge-api/6388
 class TwitchBadgesAPI(BaseAPI):
     def __init__(self, redis):
-        super().__init__(base_url="https://badges.twitch.tv/v1/badges", redis=redis)
+        super().__init__(base_url="https://badges.twitch.tv/v1/", redis=redis)
 
     def _fetch_channel_badge_sets(self, channel_id):
-        response = self.get(["channels", channel_id, "display"])
+        response = self.get(["badges", "channels", channel_id, "display"])
 
         json_badge_sets = response["badge_sets"]
         badge_sets = BadgeSets()

--- a/pajbot/apiwrappers/twitch/badges.py
+++ b/pajbot/apiwrappers/twitch/badges.py
@@ -1,0 +1,124 @@
+import logging
+
+from pajbot.apiwrappers.response_cache import ClassInstanceSerializer
+from pajbot.apiwrappers.base import BaseAPI
+
+log = logging.getLogger(__name__)
+
+
+class BadgeNotFoundError(ValueError):
+    pass
+
+
+class BadgeVersion:
+    def __init__(self, image_url_1x, image_url_2x, image_url_4x, description, title):
+        self.image_url_1x = image_url_1x
+        self.image_url_2x = image_url_2x
+        self.image_url_4x = image_url_4x
+        self.description = description
+        self.title = title
+
+    def jsonify(self):
+        return {
+            "image_url_1x": self.image_url_1x,
+            "image_url_2x": self.image_url_2x,
+            "image_url_4x": self.image_url_4x,
+            "description": self.description,
+            "title": self.title,
+        }
+
+    @staticmethod
+    def from_json(json_data):
+        image_url_1x = json_data["image_url_1x"]
+        image_url_2x = json_data["image_url_2x"]
+        image_url_4x = json_data["image_url_4x"]
+        description = json_data["description"]
+        title = json_data["title"]
+        return BadgeVersion(
+            image_url_1x=image_url_1x,
+            image_url_2x=image_url_2x,
+            image_url_4x=image_url_4x,
+            description=description,
+            title=title,
+        )
+
+
+class BadgeSet:
+    def __init__(self, set_id, versions):
+        self.set_id = set_id
+        self.versions = versions
+
+    def jsonify(self):
+        return {
+            "set_id": self.set_id,
+            "versions": {
+                badge_version_id: badge_version.jsonify() for badge_version_id, badge_version in self.versions.items()
+            },
+        }
+
+    @staticmethod
+    def from_json(json_data):
+        set_id = json_data["set_id"]
+        versions = {
+            badge_version_id: BadgeVersion.from_json(badge_version_json)
+            for badge_version_id, badge_version_json in json_data["versions"].items()
+        }
+
+        return BadgeSet(set_id=set_id, versions=versions)
+
+
+class BadgeSets(dict):
+    def jsonify(self):
+        return {badge_set_id: badge_set.jsonify() for badge_set_id, badge_set in self.items()}
+
+    @staticmethod
+    def from_json(json_data):
+        sets = {badge_set_id: BadgeSet.from_json(badge_set_json) for badge_set_id, badge_set_json in json_data.items()}
+
+        return BadgeSets(sets)
+
+
+# https://discuss.dev.twitch.tv/t/beta-badge-api/6388
+class TwitchBadgesAPI(BaseAPI):
+    def __init__(self, redis):
+        super().__init__(base_url="https://badges.twitch.tv/v1/badges", redis=redis)
+
+    def _fetch_channel_badge_sets(self, channel_id):
+        response = self.get(["channels", channel_id, "display"])
+
+        json_badge_sets = response["badge_sets"]
+        badge_sets = BadgeSets()
+
+        for badge_set_id, json_badge_set in json_badge_sets.items():
+            badge_set_versions = {}
+            for version_id, json_badge_version in json_badge_set["versions"].items():
+                badge_set_versions[version_id] = BadgeVersion(
+                    image_url_1x=json_badge_version["image_url_1x"],
+                    image_url_2x=json_badge_version["image_url_2x"],
+                    image_url_4x=json_badge_version["image_url_4x"],
+                    description=json_badge_version["description"],
+                    title=json_badge_version["title"],
+                )
+
+            badge_sets[badge_set_id] = BadgeSet(set_id=badge_set_id, versions=badge_set_versions)
+
+        return badge_sets
+
+    def get_channel_badge_sets(self, channel_id):
+        return self.cache.cache_fetch_fn(
+            redis_key=f"api:twitch:badges:channel-badge-sets:{channel_id}",
+            fetch_fn=lambda: self._fetch_channel_badge_sets(channel_id),
+            serializer=ClassInstanceSerializer(BadgeSets),
+            expiry=60 * 60,
+        )
+
+    def get_channel_subscriber_badge(self, channel_id, version="0"):
+        badge_sets = self.get_channel_badge_sets(channel_id)
+
+        if "subscriber" not in badge_sets:
+            raise BadgeNotFoundError(f"Channel({channel_id}) does not have any subscriber badges")
+
+        if version not in badge_sets["subscriber"].versions:
+            raise BadgeNotFoundError(f"Channel({channel_id}) does not have a subscriber badge with this version")
+
+        return badge_sets["subscriber"].versions[version]

--- a/pajbot/apiwrappers/twitch/badges.py
+++ b/pajbot/apiwrappers/twitch/badges.py
@@ -84,7 +84,7 @@ class TwitchBadgesAPI(BaseAPI):
         super().__init__(base_url="https://badges.twitch.tv/v1/", redis=redis)
 
     def _fetch_channel_badge_sets(self, channel_id):
-        response = self.get(["badges", "channels", channel_id, "display"])
+        response = self.get(["badges", "channels", channel_id, "display"], {"language": "en"})
 
         json_badge_sets = response["badge_sets"]
         badge_sets = BadgeSets()

--- a/pajbot/web/__init__.py
+++ b/pajbot/web/__init__.py
@@ -80,12 +80,10 @@ def init(args):
         raise ValueError("The streamer login name you entered under [main] does not exist on twitch.")
     StreamHelper.init_streamer(streamer, streamer_user_id)
 
-    if "logo" not in config["web"]:
-        try:
-            download_logo(twitch_helix_api, streamer, streamer_user_id)
-            config.set("web", "logo", "set")
-        except:
-            log.exception("Error downloading logo")
+    try:
+        download_logo(twitch_helix_api, streamer, streamer_user_id)
+    except:
+        log.exception("Error downloading the streamers profile picture")
 
     SocketClientManager.init(streamer)
 

--- a/pajbot/web/__init__.py
+++ b/pajbot/web/__init__.py
@@ -66,13 +66,22 @@ def init(args):
         salt = generate_random_salt()
         config.set("web", "pleblist_password_salt", salt.decode("utf-8"))
 
+        with open(args.config, "w") as configfile:
+            config.write(configfile)
+
     if "pleblist_password" not in config["web"]:
         salt = generate_random_salt()
         config.set("web", "pleblist_password", salt.decode("utf-8"))
 
+        with open(args.config, "w") as configfile:
+            config.write(configfile)
+
     if "secret_key" not in config["web"]:
         salt = generate_random_salt()
         config.set("web", "secret_key", salt.decode("utf-8"))
+
+        with open(args.config, "w") as configfile:
+            config.write(configfile)
 
     streamer = config["main"]["streamer"]
     streamer_user_id = twitch_helix_api.get_user_id(streamer)
@@ -86,9 +95,6 @@ def init(args):
         log.exception("Error downloading the streamers profile picture")
 
     SocketClientManager.init(streamer)
-
-    with open(args.config, "w") as configfile:
-        config.write(configfile)
 
     app.bot_modules = config["web"].get("modules", "").split()
     app.bot_commands_list = []

--- a/pajbot/web/utils.py
+++ b/pajbot/web/utils.py
@@ -26,6 +26,7 @@ from pajbot.models.module import ModuleManager
 from pajbot.models.user import User
 from pajbot.streamhelper import StreamHelper
 from pajbot.utils import time_method
+from pajbot.apiwrappers.twitch.badges import BadgeNotFoundError
 
 log = logging.getLogger(__name__)
 
@@ -87,6 +88,23 @@ def download_logo(twitch_helix_api, streamer, streamer_id):
     # downscale and save the thumbnail
     pil_image.thumbnail((64, 64), Image.ANTIALIAS)
     pil_image.save(logo_tn_path, "png")
+
+
+def download_sub_badge(twitch_badges_api, streamer, streamer_id, subscriber_badge_version):
+    try:
+        subscriber_badge = twitch_badges_api.get_channel_subscriber_badge(streamer_id, subscriber_badge_version)
+    except BadgeNotFoundError as e:
+        log.warn(f"Unable to download subscriber badge: {e}")
+        return
+
+    subscriber_badge_path = f"static/images/badge_sub_{streamer}.png"
+
+    # returns bytes
+    subscriber_badge_bytes = BaseAPI(None).get_binary(subscriber_badge.image_url_1x)
+
+    # write image...
+    with open(subscriber_badge_path, "wb") as subscriber_badge_file:
+        subscriber_badge_file.write(subscriber_badge_bytes)
 
 
 @time_method


### PR DESCRIPTION
The config key `logo` in the `web` section is now unused, the "logo" is downloaded every time the webapp starts.
The streamers sub badge is downloaded every time the webapp starts too, instead of having to be done manually.

Twitch's "badges" API has gotten an apiwrapper with this PR.

Questions for the reviewer:
 - Does the logo downloading warrant a changelog entry?

Fixes #580 

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
