### PR TITLE
use execute_delayed instead of execute_every for user rank materialized view refreshing

### DIFF
--- a/pajbot/managers/user_ranks_refresh.py
+++ b/pajbot/managers/user_ranks_refresh.py
@@ -8,21 +8,33 @@ from pajbot.utils import time_method
 
 
 class UserRanksRefreshManager:
+    jitter = 60
+    delay = 5 * 60
+
+    @staticmethod
+    def _jitter():
+        return random.randint(0, UserRanksRefreshManager.jitter)
+
     @staticmethod
     def start(action_queue):
-        # We add ±30s of jitter to try to alleviate CPU spikes when multiple pajbot instances restart at the same time.
+        # We add up to 1 minute of jitter to try to alleviate CPU spikes when multiple pajbot instances restart at the same time.
         # The jitter is added to both the initial refresh, and the scheduled one every 5 minutes.
 
         # Initial refresh
         ScheduleManager.execute_delayed(
-            random.randint(0, 30), lambda: action_queue.submit(UserRanksRefreshManager._refresh)
+            UserRanksRefreshManager._jitter(),
+            lambda: action_queue.submit(UserRanksRefreshManager._refresh, action_queue),
         )
-
-        # Run every 5 minutes, with each invocation scheduled ahead/past the 5 minute mark by a random value [-30, 30]
-        ScheduleManager.execute_every(5 * 60, lambda: action_queue.submit(UserRanksRefreshManager._refresh), jitter=30)
 
     @staticmethod
     @time_method
-    def _refresh():
-        with DBManager.create_session_scope() as db_session:
-            db_session.execute(text("REFRESH MATERIALIZED VIEW CONCURRENTLY user_rank"))
+    def _refresh(action_queue):
+        try:
+            with DBManager.create_session_scope() as db_session:
+                db_session.execute(text("REFRESH MATERIALIZED VIEW CONCURRENTLY user_rank"))
+        finally:
+            # Queue up the refresh in 5-6 minutes
+            ScheduleManager.execute_delayed(
+                UserRanksRefreshManager.delay + UserRanksRefreshManager._jitter(),
+                lambda: action_queue.submit(UserRanksRefreshManager._refresh, action_queue),
+            )


### PR DESCRIPTION
we cannot use ScheduleManagers built-in jitter here because it's not a
thing in apschedulers execute_delayed

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
