### PR TITLE
Fix !dubtrack previous/!lastsong printing current song instead of previous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Bugfix: Fixed points_rank and num_lines_rank never refreshing automatically.
 - Bugfix: Mass ping protection will no longer count inactive users (never seen before or seen longer than 2 weeks ago).
 - Bugfix: Fixed single raffle silently failing when finishing. #610
+- Bugfix: Fixed !dubtrack previous/!lastsong printing the current song instead of the previous song
 
 ## v1.38
 

--- a/pajbot/modules/dubtrack.py
+++ b/pajbot/modules/dubtrack.py
@@ -206,7 +206,7 @@ class DubtrackModule(BaseModule):
             log.exception("Dubtrack API fetch for previous song failed", exc_info=e)
             self.bot.say("There was an error fetching the previous dubtrack song monkaS")
 
-        self.api_request_and_callback(self.get_current_song, on_success, on_error)
+        self.api_request_and_callback(self.get_previous_song, on_success, on_error)
 
     def on_scheduled_new_song_check(self):
         def on_success(song_info):


### PR DESCRIPTION

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
