### PR TITLE
Fix bloat of user_rank table accumulating over time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Minor: Dates/Times on the website are now all shown in the user's time zone and formatted based on the viewer's locale. Note for the bot operator: You can remove the `timezone=` setting under `[main]`, since it's no longer needed.
 - Minor: Fix table sorting in the modules page.
 - Minor: Removed last remnants of already defunct Pleblist StreamTip integration
+- Bugfix: Fixed two more cases of long-running transactions not being closed, which in turn could cause the database server to run out of disk space (#648)
 - Bugfix: Fixed an exception and the message not being handled whenever a message contained an emote modified via the "Channel Points" Twitch feature.
 - Bugfix: Fixed an exception whenever the result of a command was being checked by the massping module.
 - Bugfix: Fixed a lot of log-spam and the subscribers refresh not working when the bot was running in its own channel. Re-authorize via `/bot_login` after this update if you were affected by this issue before.

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -50,7 +50,7 @@ from pajbot.models.user import User, UserBasics
 from pajbot.streamhelper import StreamHelper
 from pajbot.tmi import TMI
 from pajbot import utils
-from pajbot.utils import time_method, extend_version_if_possible, wait_for_redis_data_loaded
+from pajbot.utils import extend_version_if_possible, wait_for_redis_data_loaded
 
 log = logging.getLogger(__name__)
 
@@ -216,7 +216,7 @@ class Bot:
         # Commitable managers
         self.commitable = {"commands": self.commands, "banphrases": self.banphrase_manager}
 
-        self.execute_every(10 * 60, self.commit_all)
+        self.execute_every(60, self.commit_all)
         self.execute_every(1, self.do_tick)
 
         # promote the admin to level 2000
@@ -787,7 +787,6 @@ class Bot:
             message=event.arguments[0],
         )
 
-    @time_method
     def commit_all(self):
         for key, manager in self.commitable.items():
             manager.commit()

--- a/pajbot/web/routes/api/banphrases.py
+++ b/pajbot/web/routes/api/banphrases.py
@@ -71,8 +71,6 @@ class APIBanphraseTest(Resource):
     def post(self, **options):
         args = self.post_parser.parse_args()
 
-        banphrase_manager = BanphraseManager(None).load()
-
         try:
             message = str(args["message"])
         except (ValueError, KeyError):
@@ -83,7 +81,11 @@ class APIBanphraseTest(Resource):
 
         ret = {"banned": False, "input_message": message}
 
-        res = banphrase_manager.check_message(message, None)
+        banphrase_manager = BanphraseManager(None).load()
+        try:
+            res = banphrase_manager.check_message(message, None)
+        finally:
+            banphrase_manager.db_session.close()
 
         if res is not False:
             ret["banned"] = True
@@ -99,8 +101,10 @@ class APIBanphraseDump(Resource):
     @staticmethod
     def get(**options):
         banphrase_manager = BanphraseManager(None).load()
-
-        return banphrase_manager.enabled_banphrases
+        try:
+            return banphrase_manager.enabled_banphrases
+        finally:
+            banphrase_manager.db_session.close()
 
 
 def init(api):


### PR DESCRIPTION
This page of the PostgreSQL documentation is quite relevant here: https://www.postgresql.org/docs/current/routine-vacuuming.html

Quoting the particularly important bits (emphasis mine):

> In PostgreSQL, an UPDATE or DELETE of a row does not immediately remove the old version of the row. This approach is necessary to gain the benefits of multiversion concurrency control (MVCC, see Chapter 13): **the row version must not be deleted while it is still potentially visible to other transactions**. But eventually, an outdated or deleted row version is no longer of interest to any transaction. The space it occupies must then be reclaimed for reuse by new rows, to avoid unbounded growth of disk space requirements. This is done by running VACUUM.

> The **standard form of VACUUM** removes dead row versions in tables and indexes and **marks the space available for future reuse**. However, **it will not return the space to the operating system**, except in the special case where one or more pages at the end of a table become entirely free and an exclusive table lock can be easily obtained. In contrast, VACUUM FULL actively compacts tables by writing a complete new version of the table file with no dead space. This minimizes the size of the table, but can take a long time. It also requires extra disk space for the new copy of the table, until the operation completes.

> The usual goal of routine vacuuming is to do standard VACUUMs often enough to avoid needing VACUUM FULL. The autovacuum daemon attempts to work this way, and in fact will never issue VACUUM FULL. In this approach, the idea is not to keep tables at their minimum size, but to maintain steady-state usage of disk space: each table occupies space equivalent to its minimum size plus however much space gets used up between vacuumings. Although VACUUM FULL can be used to shrink a table back to its minimum size and return the disk space to the operating system, there is not much point in this if the table will just grow again in the future. Thus, moderately-frequent standard VACUUM runs are a better approach than infrequent VACUUM FULL runs for maintaining heavily-updated tables.

You can even watch the bot do its things with these useful queries:

```sql
-- Show long-running transactions (> 1 second) and their last SQL statement:
SELECT NOW() - xact_start AS xact_runtime, query
FROM pg_stat_activity
where now() - xact_start > '1 second'::interval
ORDER BY xact_start; \watch 1

-- Show how many dead tuples exist in our user_rank views
-- (standard VACUUM reclaims these for re-use)
SELECT schemaname || '.' || relname, n_dead_tup
FROM pg_stat_user_tables
WHERE relname = 'user_rank'
ORDER BY n_dead_tup DESC; \watch 1

-- Show the on-disk space of tables
SELECT nspname || '.' || relname AS "relation",
    pg_size_pretty(pg_total_relation_size(C.oid)) AS "total_size"
  FROM pg_class C
  LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace)
  WHERE nspname NOT IN ('pg_catalog', 'information_schema')
    AND C.relkind <> 'i'
    AND nspname !~ '^pg_toast'
  ORDER BY pg_total_relation_size(C.oid) DESC
  LIMIT 20; \watch 1
```

With these three queries running and refreshing automatically, you can see this cycle take effect:

1. The bot issues a refresh on the materialized view. You can see this query running via the first query - it shows up as a long-running transaction.
2. You will see the on-disk space of the materialized view grow as the query gets near the finish point
3. The refresh on the materialized view will finish at some point - at the same point, the `n_dead_tup` on the second query will suddenly jump to a high number (in my case, 3.5 million)
4. The autovacuum daemon will at some time decide to perform a vacuum: You will see this on the first query as well. It issues a `VACUUM ANALYZE pajbot1_forsen.user_rank` which takes 2-3 minutes in my case.
5. Once the autovacuum finishes, n_dead_tup will jump to 0 on the rank that was just vacuumed. Note! the `total_size` (on-disk size) of the table will not decrease, because the autovacuum didn't do a `FULL` vacuum.
6. The cycle repeats - the bot issues a refresh on the materialized view.
7. However, when this refresh finishes, the table size does not double again. The refresh reuses the size freed by the autovacuum daemon - so no space leak is created

So why didn't this cycle work previously? Let's read that first paragraph from the PostgreSQL documentation again!

> **the row version must not be deleted while it is still potentially visible to other transactions**

The database server was not allowed to delete the dead rows in the user_rank view because a long-running idle transaction that was not properly closed could potentially still access it.

Here is a screenshot of the monitoring for my own instance of PostgreSQL, running 4 instances of pajbot, and observe the extremely high long-running transaction time (transaction times are supposed to range in the milliseconds, mind you):
![image](https://user-images.githubusercontent.com/1629196/68161551-5fbcf480-ff56-11e9-931a-d031aa8b3bd2.png)

The long-running transaction could quickly be identified using the first helper query. The query in question was related to banphrases, and it quickly boiled down to be the shared `db_session` in `BanphraseManager` that was not closed in the banphrase test API. This PR fixes that.

Also, to keep the transaction lifespan short on the main bot's transactions (which includes the db_session of the banphrase manager), the commit interval has been decreased to once-perminute, and the log message that goes with it has been removed.

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
