### PR TITLE
Issue explicit VACUUM after user rank table refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Minor: Fix table sorting in the modules page.
 - Minor: Removed last remnants of already defunct Pleblist StreamTip integration
 - Bugfix: Fixed two more cases of long-running transactions not being closed, which in turn could cause the database server to run out of disk space (#648)
+- Bugfix: Added explicit VACUUM of user_rank relation after refresh to ensure the database server does not run out of disk space
 - Bugfix: Fixed an exception and the message not being handled whenever a message contained an emote modified via the "Channel Points" Twitch feature.
 - Bugfix: Fixed an exception whenever the result of a command was being checked by the massping module.
 - Bugfix: Fixed a lot of log-spam and the subscribers refresh not working when the bot was running in its own channel. Re-authorize via `/bot_login` after this update if you were affected by this issue before.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 - Minor: Fix table sorting in the modules page.
 - Minor: Removed last remnants of already defunct Pleblist StreamTip integration
 - Bugfix: Fixed two more cases of long-running transactions not being closed, which in turn could cause the database server to run out of disk space (#648)
-- Bugfix: Added explicit VACUUM of user_rank relation after refresh to ensure the database server does not run out of disk space
+- Bugfix: Added explicit VACUUM of user_rank relation after refresh to ensure the database server does not run out of disk space, even if you have a lot of bots (with a lot of users in the database) running on the same server.
 - Bugfix: Fixed an exception and the message not being handled whenever a message contained an emote modified via the "Channel Points" Twitch feature.
 - Bugfix: Fixed an exception whenever the result of a command was being checked by the massping module.
 - Bugfix: Fixed a lot of log-spam and the subscribers refresh not working when the bot was running in its own channel. Re-authorize via `/bot_login` after this update if you were affected by this issue before.

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -140,10 +140,10 @@ class Bot:
         # with self.conn:  # transaction control, does NOT close the connection
         #     with self.conn.cursor() as cursor:  # auto resource release of cursor
         #         cursor.execute("SOME SQL")
-        sql_conn = DBManager.engine.connect().connection.connection
-        sql_migratable = DatabaseMigratable(sql_conn)
-        sql_migration = Migration(sql_migratable, pajbot.migration_revisions.db, self)
-        sql_migration.run()
+        with DBManager.create_dbapi_connection_scope() as sql_conn:
+            sql_migratable = DatabaseMigratable(sql_conn)
+            sql_migration = Migration(sql_migratable, pajbot.migration_revisions.db, self)
+            sql_migration.run()
 
         # Redis migrations
         redis_migratable = RedisMigratable(redis_options=redis_options, namespace=self.streamer)

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -132,14 +132,6 @@ class Bot:
         StreamHelper.init_streamer(self.streamer, self.streamer_user_id)
 
         # SQL migrations
-        # engine.connect() returns a SQLAlchemy `Connection` object.
-        # engine.connect().connection returns a SQLAlchemy `_ConnectionFairy` object.
-        # engine.connect().connection.connection is the underlying psycopg2 connection.
-        # we need the psycopg2 connection, so we can do transaction control using the connection as a context manager
-        # e.g. (from the implementation of DatabaseMigratable):
-        # with self.conn:  # transaction control, does NOT close the connection
-        #     with self.conn.cursor() as cursor:  # auto resource release of cursor
-        #         cursor.execute("SOME SQL")
         with DBManager.create_dbapi_connection_scope() as sql_conn:
             sql_migratable = DatabaseMigratable(sql_conn)
             sql_migration = Migration(sql_migratable, pajbot.migration_revisions.db, self)

--- a/pajbot/managers/db.py
+++ b/pajbot/managers/db.py
@@ -1,6 +1,7 @@
 import logging
 from contextlib import contextmanager
 
+from psycopg2.extensions import STATUS_IN_TRANSACTION
 from sqlalchemy import create_engine
 from sqlalchemy import event
 from sqlalchemy import inspect
@@ -135,6 +136,75 @@ class DBManager:
             raise
         finally:
             session.close()
+
+    @staticmethod
+    @contextmanager
+    def create_dbapi_connection_scope(autocommit=False):
+        # This method's contextmanager just checks the connection out, sets autocommit if desired, and
+        # returns the connection to the pool when the contextmanager exits
+        # It does not perform transaction control! create_dbapi_session_scope is more useful since it provides
+        # an automatic COMMIT/ROLLBACK mechanism, and also returns a DBAPI Session instead of Connection.
+
+        # https://docs.sqlalchemy.org/en/13/core/connections.html#sqlalchemy.engine.Engine.raw_connection
+        pool_connection = DBManager.engine.raw_connection()
+
+        # Quoting from the SQLAlchemy docs:
+        # > The returned object is a proxied version of the DBAPI connection object used by the underlying driver in use.
+        # To be able to use the connection as a contextmanager for transaction control,
+        # we need the actual underlying connection, the SQLAlchemy proxy will not work for this.
+        raw_connection = pool_connection.connection
+
+        try:
+            if autocommit:
+                # The parameter "pool_pre_ping=True" from create_engine() above makes SQLAlchemy issue a
+                # "SELECT 1" to test the connection works before returning it from the connection pool.
+                # Even the simple "SELECT 1" has automatically begun a transaction, and the connection
+                # will now be "idle in transaction".
+                #
+                # Because we can only enable autocommit on "idle" connections, we need to ROLLBACK if a transaction
+                # is ongoing first:
+                if raw_connection.status == STATUS_IN_TRANSACTION:
+                    raw_connection.rollback()
+                # http://initd.org/psycopg/docs/connection.html#connection.autocommit
+                raw_connection.autocommit = True
+
+            try:
+                yield raw_connection
+            finally:
+                # We want to reset the connection to a clean state in the end, so we don't return connections
+                # to the pool that are in an ongoing transaction, or whose transaction is aborted
+                # (typical error message: "ERROR: current transaction is aborted,
+                # commands ignored until end of transaction block")
+                if raw_connection.status == STATUS_IN_TRANSACTION:
+                    raw_connection.rollback()
+        finally:
+            if autocommit:
+                # Because the connection is returned to the pool, we want to reset the autocommit state on it
+                raw_connection.autocommit = False
+
+            # Finally release connection back to the pool (notice we use .close() on the pool connection,
+            # not raw_connection which would close the connection for good)
+            pool_connection.close()
+
+    @staticmethod
+    @contextmanager
+    def create_dbapi_session_scope(autocommit=False):
+        # The create_dbapi_connection_scope context manager just does basic setup/cleanup of resources,
+        # not transaction control
+        with DBManager.create_dbapi_connection_scope(autocommit=autocommit) as sql_conn:
+            if autocommit:
+                # Using the cursor as a context manager just does cleanup on the resources of the cursor,
+                # it does not perform transaction control with BEGIN/COMMIT/ROLLBACK.
+                with sql_conn.cursor() as cursor:
+                    yield cursor
+            else:
+                # Using the connection as a context manager however gives us BEGIN/COMMIT/ROLLBACK transaction control.
+                # The connection is automatically COMMITed should the inner block return without an exception,
+                # or the connection is ROLLBACKed if an exception occurs.
+                with sql_conn:
+                    # Now use cursor as context manager again, just to release resources correctly
+                    with sql_conn.cursor() as cursor:
+                        yield cursor
 
     @staticmethod
     def debug(raw_object):

--- a/pajbot/managers/db.py
+++ b/pajbot/managers/db.py
@@ -188,7 +188,7 @@ class DBManager:
 
     @staticmethod
     @contextmanager
-    def create_dbapi_session_scope(autocommit=False):
+    def create_dbapi_cursor_scope(autocommit=False):
         # The create_dbapi_connection_scope context manager just does basic setup/cleanup of resources,
         # not transaction control
         with DBManager.create_dbapi_connection_scope(autocommit=autocommit) as sql_conn:

--- a/pajbot/managers/db.py
+++ b/pajbot/managers/db.py
@@ -202,7 +202,7 @@ class DBManager:
                 # The connection is automatically COMMITed should the inner block return without an exception,
                 # or the connection is ROLLBACKed if an exception occurs.
                 with sql_conn:
-                    # Now use cursor as context manager again, just to release resources correctly
+                    # Now use cursor as context manager, to release resources correctly
                     with sql_conn.cursor() as cursor:
                         yield cursor
 

--- a/pajbot/managers/user_ranks_refresh.py
+++ b/pajbot/managers/user_ranks_refresh.py
@@ -28,9 +28,9 @@ class UserRanksRefreshManager:
     @time_method
     def _refresh(action_queue):
         try:
-            with DBManager.create_dbapi_cursor_scope(autocommit=True) as db_session:
-                db_session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY user_rank")
-                db_session.execute("VACUUM user_rank")
+            with DBManager.create_dbapi_cursor_scope(autocommit=True) as cursor:
+                cursor.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY user_rank")
+                cursor.execute("VACUUM user_rank")
         finally:
             # Queue up the refresh in 5-6 minutes
             ScheduleManager.execute_delayed(

--- a/pajbot/managers/user_ranks_refresh.py
+++ b/pajbot/managers/user_ranks_refresh.py
@@ -28,7 +28,7 @@ class UserRanksRefreshManager:
     @time_method
     def _refresh(action_queue):
         try:
-            with DBManager.create_dbapi_session_scope(autocommit=True) as db_session:
+            with DBManager.create_dbapi_cursor_scope(autocommit=True) as db_session:
                 db_session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY user_rank")
                 db_session.execute("VACUUM user_rank")
         finally:

--- a/pajbot/managers/user_ranks_refresh.py
+++ b/pajbot/managers/user_ranks_refresh.py
@@ -1,7 +1,5 @@
 import random
 
-from sqlalchemy import text
-
 from pajbot.managers.db import DBManager
 from pajbot.managers.schedule import ScheduleManager
 from pajbot.utils import time_method
@@ -30,8 +28,9 @@ class UserRanksRefreshManager:
     @time_method
     def _refresh(action_queue):
         try:
-            with DBManager.create_session_scope() as db_session:
-                db_session.execute(text("REFRESH MATERIALIZED VIEW CONCURRENTLY user_rank"))
+            with DBManager.create_dbapi_session_scope(autocommit=True) as db_session:
+                db_session.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY user_rank")
+                db_session.execute("VACUUM user_rank")
         finally:
             # Queue up the refresh in 5-6 minutes
             ScheduleManager.execute_delayed(


### PR DESCRIPTION
Please test with care, I don't know if this works or solves anything.
Also, we should consider setting autovacuum to false on user_rank if we are going to do this, or tweak some autovacuum settings?

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
