### PR TITLE
Update contact page with relevant information.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
   sudo -u pajbot psql pajbot -c "SET search_path=pajbot1_streamer_name" -f ./scripts/restore-pleblist-songs.sql
   ```
 
+- Minor: Bot maintainer/host information can now be added to the config file and displayed on the `/contact`-page. See bottom of updated example config for an example.
 - Minor: Emote command (e.g. !bttvemotes) cooldowns and level can now be configured in the modules settings.
 - Minor: The end message sent when a negative raffle ends now says "lost X points" correctly, instead of "won -X points".
 - Minor: Duels now automatically expire and get cancelled if they are not accepted within 5 minutes (Time amount can be configured as a module setting).

--- a/install-docs/debian10/kkonatestbroadcaster.ini
+++ b/install-docs/debian10/kkonatestbroadcaster.ini
@@ -99,3 +99,8 @@ host = wss://bot.kkonatestbroadcaster.tv/clrsocket
 ; you can optionally populate this for pleblist
 [youtube]
 developer_key = abc
+
+; information about you, the maintainer and host of this bot. will be shown on the /contact page
+[maintainer]
+name = KKonaTestAdmin
+contact_string = You can contact me over at <a href="https://KKonaTestAdmin.se/contact">CONTACT LINK</a>

--- a/pajbot/web/routes/base/contact.py
+++ b/pajbot/web/routes/base/contact.py
@@ -1,7 +1,22 @@
 from flask import render_template
 
+import logging
+
+log = logging.getLogger(__name__)
+
 
 def init(app):
+    try:
+        maintainer = {
+            "name": app.bot_config["maintainer"]["name"],
+            "contact_string": app.bot_config["maintainer"]["contact_string"],
+        }
+    except KeyError:
+        log.warn(
+            "Missing name and/or contact_string in config file, no direct contact info will be shown on the /contact page. See example config file"
+        )
+        maintainer = None
+
     @app.route("/contact")
     def contact():
-        return render_template("contact.html")
+        return render_template("contact.html", maintainer=maintainer)

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -4,8 +4,11 @@
 {% block body %}
 <div class="ui segment">
 <h2>Contact</h2>
-<p>Hi, I'm pajlada! I'm the current maintainer and developer of {{ bot.name }}.</p>
-<p>{{ bot.name }} is running on the <strong>pajbot</strong> source, which is coded in Python.</p>
-<p>Got any questions or comments about the bot or the website? <a href="http://twitch.tv/message/compose?to=pajlada">Let me know by sending me a twitch message!</a></p>
+{% if maintainer is not none %}
+<p>Hi, I'm {{ maintainer.name }}! I'm the host and maintainer of {{ bot.name }}.</p>
+<p>{{ maintainer.contact_string|safe }}</p>
+{% endif %}
+<p>{{ bot.name }} is running on the <a href="https://github.com/pajbot/pajbot"><strong>pajbot</strong></a> source, which is written in Python.</p>
+<p>Got any questions or comments about the bot or the website? <a href="https://discord.gg/qbRE8WR">You can join pajlada's Discord for support!</a></p>
 </div>
 {% endblock %}


### PR DESCRIPTION
There's now a link to my discord which has pajbot channels for support/questions.

A section has been added to the config file that the /contact page
reads, with the bot maintainer's information. currently the name and
contact_string fields should be filled in. see kkonatestbroadcaster.ini
for an example. This section lets you, the hoster who isn't pajlada, add
contact information on the bot website.

Fixes #652
Fixed #659



Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
