### PR TITLE
Error out early in command substitution if a substitution returned None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bugfix: Fixed users not being banned on sight if they were "banned on pajbot" (`!permaban` command/feature).
 - Bugfix: Fixed linkchecker blacklist commands not working.
 - Bugfix: Fixed linkchecker blacklisted links not timing users out.
+- Bugfix: Fixed strictargs not cancelling message response if a filter was applied to it. (#677)
 
 ## v1.39
 

--- a/pajbot/models/action.py
+++ b/pajbot/models/action.py
@@ -66,6 +66,8 @@ def apply_substitutions(text, substitutions, bot, extra):
             log.error("Unknown param for response.")
             continue
         value = sub.cb(param, extra)
+        if value is None:
+            return None
         try:
             for f in sub.filters:
                 value = bot.apply_filter(value, f)


### PR DESCRIPTION
This fixes #677

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
