### PR TITLE
Fix wrong indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Bugfix: Respect `timeout_length` setting in Link Checker module
 - Bugfix: Fixed potential issues with users with recycled Twitch usernames (cases when two users in the database shared the same Twitch username).
 - Bugfix: Links are now checked against whitelisted links in case the "Disallow links from X" settings are enabled
+- Bugfix: Single-raffle winners are now properly announced if the "show on clr" option is disabled
 
 ## v1.40
 

--- a/pajbot/modules/raffle.py
+++ b/pajbot/modules/raffle.py
@@ -324,7 +324,8 @@ class RaffleModule(BaseModule):
                 self.bot.websocket_manager.emit(
                     "notification", {"message": f"{winner} {format_win(self.raffle_points)} points in the raffle!"}
                 )
-                self.bot.me(f"The raffle has finished! {winner} {format_win(self.raffle_points)} points! PogChamp")
+
+            self.bot.me(f"The raffle has finished! {winner} {format_win(self.raffle_points)} points! PogChamp")
 
             winner.points += self.raffle_points
 


### PR DESCRIPTION
As is, raffles will only display in chat when display_on_clr is enabled.