### PR TITLE
Fix duels not properly cancelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Minor: Added `bot_domain` variable
 - Minor: Added more social media options (Discord, Patreon, Snapchat)
 - Minor: Changed requests should now have the appropriate `User-Agent`.
+- Bugfix: Fixed duels not being cancelled
 - Bugfix: Fixed duel stats not being applied to the right person (#717)
 - Bugfix: Respect `timeout_length` setting in Link Checker module
 - Bugfix: Fixed potential issues with users with recycled Twitch usernames (cases when two users in the database shared the same Twitch username).

--- a/pajbot/modules/duel.py
+++ b/pajbot/modules/duel.py
@@ -236,10 +236,11 @@ class DuelModule(BaseModule):
         with DBManager.create_session_scope() as db_session:
             challenged = User.find_by_id(db_session, self.duel_requests[source.id])
             bot.whisper(source, f"You have cancelled the duel vs {challenged}")
-        del self.duel_targets[challenged.id]
-        del self.duel_request_price[source.id]
-        del self.duel_begin_time[source.id]
-        del self.duel_requests[source.id]
+
+            del self.duel_targets[challenged.id]
+            del self.duel_request_price[source.id]
+            del self.duel_begin_time[source.id]
+            del self.duel_requests[source.id]
 
     def accept_duel(self, bot, source, **rest):
         """
@@ -328,10 +329,10 @@ class DuelModule(BaseModule):
             bot.whisper(source, f"You have declined the duel vs {requestor}")
             bot.whisper(requestor, f"{source} declined the duel challenge with you.")
 
-        del self.duel_targets[source.id]
-        del self.duel_requests[requestor.id]
-        del self.duel_request_price[requestor.id]
-        del self.duel_begin_time[requestor.id]
+            del self.d  uel_targets[source.id]
+            del self.duel_requests[requestor.id]
+            del self.duel_request_price[requestor.id]
+            del self.duel_begin_time[requestor.id]
 
     def status_duel(self, bot, source, **rest):
         """
@@ -388,10 +389,10 @@ class DuelModule(BaseModule):
                         source, f"{challenged} didn't accept your duel request in time, so the duel has been cancelled."
                     )
 
-            del self.duel_targets[self.duel_requests[source.id]]
-            del self.duel_requests[source.id]
-            del self.duel_request_price[source.id]
-            del self.duel_begin_time[source.id]
+                del self.duel_targets[self.duel_requests[source.id]]
+                del self.duel_requests[source.id]
+                del self.duel_request_price[source.id]
+                del self.duel_begin_time[source.id]
 
     def enable(self, bot):
         if not bot:

--- a/pajbot/modules/duel.py
+++ b/pajbot/modules/duel.py
@@ -329,7 +329,7 @@ class DuelModule(BaseModule):
             bot.whisper(source, f"You have declined the duel vs {requestor}")
             bot.whisper(requestor, f"{source} declined the duel challenge with you.")
 
-            del self.d  uel_targets[source.id]
+            del self.duel_targets[source.id]
             del self.duel_requests[requestor.id]
             del self.duel_request_price[requestor.id]
             del self.duel_begin_time[requestor.id]


### PR DESCRIPTION
Changelog updated since !cancelduel would also fail before the two other bugs #717 introduced
- [X] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
