### PR TITLE
Fix typeemote quest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Bugfix: Fixed the "type emote" quest by ensuring all emote IDs are strings. (#768)
+
 ## v1.41
 
 - Major: Add support for streaming tweets through [tweet-provider](https://github.com/pajbot/tweet-provider) instead of going directly through Twitter.

--- a/pajbot/apiwrappers/ffz.py
+++ b/pajbot/apiwrappers/ffz.py
@@ -17,7 +17,7 @@ class FFZAPI(BaseAPI):
                 # FFZ returns relative URLs (e.g. //cdn.frankerfacez.com/...)
                 # so we fill in the scheme if it's missing :)
                 urls = {size: FFZAPI.fill_in_url_scheme(url) for size, url in emote["urls"].items()}
-                emotes.append(Emote(code=emote["name"], provider="ffz", id=emote["id"], urls=urls))
+                emotes.append(Emote(code=emote["name"], provider="ffz", id=str(emote["id"]), urls=urls))
 
         return emotes
 

--- a/pajbot/apiwrappers/twitch/kraken_v5.py
+++ b/pajbot/apiwrappers/twitch/kraken_v5.py
@@ -71,7 +71,7 @@ class TwitchKrakenV5API(BaseTwitchAPI):
         from pajbot.managers.emote import EmoteManager
 
         resp = self.get("/chat/emoticon_images", params={"emotesets": "0"})
-        return [EmoteManager.twitch_emote(data["id"], data["code"]) for data in resp["emoticon_sets"]["0"]]
+        return [EmoteManager.twitch_emote(str(data["id"]), data["code"]) for data in resp["emoticon_sets"]["0"]]
 
     def get_global_emotes(self, force_fetch=False):
         return self.cache.cache_fetch_fn(

--- a/pajbot/apiwrappers/twitchemotesapi.py
+++ b/pajbot/apiwrappers/twitchemotesapi.py
@@ -38,7 +38,7 @@ class TwitchEmotesAPI(BaseAPI):
                     tier = 2
                 else:
                     tier = 3
-                ret_data[tier - 1].append(EmoteManager.twitch_emote(emote["id"], emote["code"]))
+                ret_data[tier - 1].append(EmoteManager.twitch_emote(str(emote["id"]), emote["code"]))
             return ret_data
 
         except HTTPError as e:

--- a/pajbot/migration_revisions/redis/0002_fix_bad_quest_emote_json.py
+++ b/pajbot/migration_revisions/redis/0002_fix_bad_quest_emote_json.py
@@ -1,0 +1,18 @@
+import json
+
+
+def up(redis, bot):
+    # invalidate bad emotes cache
+    redis.delete("api:twitch:kraken:v5:global-emotes")
+    redis.delete(f"api:twitch_emotes:channel-emotes:{bot.streamer}")
+    redis.delete(f"api:ffz:channel-emotes:{bot.streamer}")
+    redis.delete("api:ffz:global-emotes")
+
+    current_emote_key = f"{bot.streamer}:current_quest_emote"
+    current_emote_json = redis.get(current_emote_key)
+    if current_emote_json is not None:
+        # ensure emote id is a string
+        current_emote = json.loads(current_emote_json)
+        if not isinstance(current_emote["id"], str):
+            current_emote["id"] = str(current_emote["id"])
+            redis.set(current_emote_key, json.dumps(current_emote))

--- a/pajbot/models/emote.py
+++ b/pajbot/models/emote.py
@@ -12,6 +12,8 @@ class Emote:
     def __init__(self, code, provider, id, urls):
         self.code = code
         self.provider = provider
+        if not isinstance(id, str):
+            raise ValueError("id parameter must be a string")
         self.id = id
         self.urls = urls
 


### PR DESCRIPTION
it wasn't working because emote IDs were strings when we read them through irc, but integers in some of the APIs. All APIs that need it now convert their emote IDs to strings.

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
