### PR TITLE
fix for P&SL module and for the module reorder

### DIFF
--- a/configs/example.ini
+++ b/configs/example.ini
@@ -117,3 +117,8 @@ developer_key = abc
 [maintainer]
 name = KKonaTestAdmin
 contact_string = You can contact me over at <a href="https://KKonaTestAdmin.se/contact">CONTACT LINK</a>
+
+; credentials for the P&SL module
+[pnsl]
+; bearer token can be generated here https://bot.tetyys.com/swagger/index.html
+; token = abcef

--- a/pajbot/modules/__init__.py
+++ b/pajbot/modules/__init__.py
@@ -71,7 +71,6 @@ from pajbot.modules.trivia import TriviaModule
 from pajbot.modules.vanish import VanishModule
 from pajbot.modules.warning import WarningModule
 from pajbot.modules.wolfram import WolframModule
-from pajbot.modules.pnsl import PNSLModule
 
 available_modules = [
     AbCommandModule,

--- a/pajbot/modules/pnsl.py
+++ b/pajbot/modules/pnsl.py
@@ -76,7 +76,9 @@ class PNSLModule(BaseModule):
 
         log.info(f"[P&SL] User {source.name} running list {guid} with {len(privmsg_list)} entries")
 
-        bot.privmsg_arr_chunked(privmsg_list)
+        bot.privmsg_arr_chunked(
+            privmsg_list, per_chunk=self.settings["per_chunk"], chunk_delay=self.settings["chunk_delay"]
+        )
 
     def load_commands(self, **options):
         self.commands["runpnsl"] = Command.raw_command(

--- a/pajbot/modules/pnsl.py
+++ b/pajbot/modules/pnsl.py
@@ -61,7 +61,7 @@ class PNSLModule(BaseModule):
             bot.whisper(source, f"Missing P&SL token in config.ini. talk to @{bot.admin} BabyRage")
             return False
 
-        guid = message.lstrip("https://bot.tetyys.com/BotList/")
+        guid = message.replace("https://bot.tetyys.com/BotList/", "")
 
         headers = {"Authorization": f"Bearer {self.pnsl_token}"}
 


### PR DESCRIPTION
module reorder had a double import

fix so P&SL actually respects chunk_delay and per_chunk settings

fix so P&SL strips the url properly

add example config entry for the module


Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

<!--
Other things to do before commit (the CI will validate you did this):

If you changed any markdown files (e.g. changelog, readme, etc.)
./scripts/reformat-markdown.sh

If you changed any python code (reformat and run linter):
./scripts/reformat-python.sh
flake8
-->
