### PR TITLE
Added a ban reason for "!permaban"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Minor: Added ban reason for "!permaban"
+
 ## v1.42
 
 - Minor: Add ability to run P&SL lists with !runpnsl command

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -647,7 +647,7 @@ class Bot:
             source.subscriber = tags["subscriber"] == "1"
 
         if not whisper and source.banned:
-            self.ban(source)
+            self.ban(source, reason=f"User is on the {self.nickname} banlist. Contact a moderator level 1000 or higher for unban.") 
             return False
 
         # Parse emotes in the message

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -649,7 +649,7 @@ class Bot:
         if not whisper and source.banned:
             self.ban(
                 source,
-                reason=f"User is on the {self.nickname} banlist. Contact a moderator level 1000 or higher for unban."
+                reason=f"User is on the {self.nickname} banlist. Contact a moderator level 1000 or higher for unban.",
             ) 
             return False
 

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -647,7 +647,10 @@ class Bot:
             source.subscriber = tags["subscriber"] == "1"
 
         if not whisper and source.banned:
-            self.ban(source, reason=f"User is on the {self.nickname} banlist. Contact a moderator level 1000 or higher for unban.") 
+            self.ban(
+                source,
+                reason=f"User is on the {self.nickname} banlist. Contact a moderator level 1000 or higher for unban."
+            ) 
             return False
 
         # Parse emotes in the message

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -650,7 +650,7 @@ class Bot:
             self.ban(
                 source,
                 reason=f"User is on the {self.nickname} banlist. Contact a moderator level 1000 or higher for unban.",
-            ) 
+            )
             return False
 
         # Parse emotes in the message


### PR DESCRIPTION
Added a generic ban reason for !permaban as it had no ban reason before which could cause confusion as it could be seen as the bot "randomly" banning if the !permaban usage was forgotten.

Also I included the level section in the ban reason only because the user does not receive the ban reason so it would not cause any confusion for them, just as a note for the mods.

![image](https://user-images.githubusercontent.com/41973452/74964549-9cb3d680-53e1-11ea-864d-5e63c70c800d.png)


Pull request checklist:

- [X] `CHANGELOG.md` was updated, if applicable

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
