### PR TITLE
Add slice filter

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,7 @@
 Pull request checklist:
 
 - [ ] `CHANGELOG.md` was updated, if applicable
+- [ ] Documentation in docs/ or install-docs/ was updated, if applicable
 
 <!--
 Don't forget to check and reformat your code:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Minor: You can now set the points cost for the `!$timeout`/`!untimeout`/`!unban`/`!$subon`/`!$suboff` commands as high as 1 million (was 30k/10k before).
 - Minor: Fixed some minor grammar issues, also modified some module names and descriptions
 - Minor: "Stream Update Commands" module is now configurable (custom trigger, custom level requirement)
+- Minor: Added `slice` filter that can slice up a string. See https://docs.python.org/3/library/functions.html#slice
 
 ## v1.42
 

--- a/docs/variables.txt
+++ b/docs/variables.txt
@@ -39,6 +39,7 @@ Available filters:
             "or_else": _filter_or_else,
             "or_broadcaster": self._filter_or_broadcaster,
             "or_streamer": self._filter_or_broadcaster,
+            "slice": _filter_slice,
         }
 
 

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -935,13 +935,10 @@ def _filter_or_else(var, args):
 
 def _filter_slice(var, args):
     m = SLICE_REGEX.match(args[0])
-    print(args[0])
     if m:
         groups = m.groups()
-        print(groups)
         if groups[0] is not None and groups[2] is None:
             if groups[1] is None:
-                print(m)
                 # 0
                 return var[slice(int(groups[0]), int(groups[0]) + 1)]
 

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -58,6 +58,8 @@ URL_REGEX = re.compile(
     re.IGNORECASE,
 )
 
+SLICE_REGEX = re.compile(r"(-?\d+)?(:?(-?\d+)?)?")
+
 
 class Bot:
     """
@@ -862,6 +864,7 @@ class Bot:
             "or_else": _filter_or_else,
             "or_broadcaster": self._filter_or_broadcaster,
             "or_streamer": self._filter_or_broadcaster,
+            "slice": _filter_slice,
         }
         if f.name in available_filters:
             return available_filters[f.name](resp, f.arguments)
@@ -928,3 +931,30 @@ def _filter_or_else(var, args):
         return args[0]
     else:
         return var
+
+
+def _filter_slice(var, args):
+    m = SLICE_REGEX.match(args[0])
+    print(args[0])
+    if m:
+        groups = m.groups()
+        print(groups)
+        if groups[0] is not None and groups[2] is None:
+            if groups[1] is None:
+                print(m)
+                # 0
+                return var[slice(int(groups[0]), int(groups[0]) + 1)]
+
+            # 0:
+            return var[slice(int(groups[0]), None)]
+        if groups[0] is not None and groups[2] is not None:
+            # 0:0
+            return var[slice(int(groups[0]), int(groups[2]))]
+
+        if groups[0] is None and groups[2] is not None:
+            # :0
+            return var[slice(int(groups[2]))]
+
+        return var
+
+    return var


### PR DESCRIPTION
Example usage: `$(args:0|slice(:-1)` would trim the last character of the users input
`foobar` turns to `fooba`. same as `string[:-1]`


https://www.programiz.com/python-programming/methods/built-in/slice



Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
