### PR TITLE
Fix founder badge logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Minor: Added `slice` filter that can slice up a string. See https://docs.python.org/3/library/functions.html#slice
 - Minor: Removed pleblist stuff. Namely: password/key generation and password/key checking. Also removed youtube config entry from the example config file.
 - Bugfix: Fixed web process not starting if the venv was recently installed or updated. (#816)
+- Bugfix: Fixed founders not counting as subscribers (#820)
 
 ## v1.42
 

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -643,7 +643,7 @@ class Bot:
         emote_tag = tags["emotes"]
         msg_id = tags.get("id", None)  # None on whispers!
         badges_string = tags.get("badges", "")
-        badges = dict((badge.split('/') for badge in filter(None, badges_string.split(','))))
+        badges = dict((badge.split("/") for badge in filter(None, badges_string.split(","))))
 
         if not whisper and event.target == self.channel:
             # Moderator or broadcaster, both count

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -642,11 +642,14 @@ class Bot:
 
         emote_tag = tags["emotes"]
         msg_id = tags.get("id", None)  # None on whispers!
+        badges_string = tags.get("badges", "")
+        badges = dict((badge.split('/') for badge in filter(None, badges_string.split(','))))
 
         if not whisper and event.target == self.channel:
             # Moderator or broadcaster, both count
             source.moderator = tags["mod"] == "1" or source.id == self.streamer_user_id
-            source.subscriber = tags["subscriber"] == "1"
+            # Having the founder badge means that the subscriber tag is set to 0. Therefore it's more stable to just check badges
+            source.subscriber = "founder" in badges or "subscriber" in badges
 
         if not whisper and source.banned:
             self.ban(

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -643,7 +643,7 @@ class Bot:
         emote_tag = tags["emotes"]
         msg_id = tags.get("id", None)  # None on whispers!
         badges_string = tags.get("badges", "")
-        badges = dict((badge.split("/") for badge in filter(None, badges_string.split(","))))
+        badges = dict((badge.split("/") for badge in badges_string.split(",") if badge != ""))
 
         if not whisper and event.target == self.channel:
             # Moderator or broadcaster, both count


### PR DESCRIPTION
When a user has the founder badge, the "subscriber" tag is surprisingly
set to 0. We previously relied on the "subscriber" tag, but now instead
check whether the user has a subscriber or founder badge.

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
