### PR TITLE
Fix warnings for unrecognised number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unversioned
+- Bugfix: Fixed warnings in the admin playsounds page
 
 ## v1.43
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unversioned
+
 - Bugfix: Fixed warnings in the admin playsounds page
 
 ## v1.43

--- a/templates/admin/playsounds.html
+++ b/templates/admin/playsounds.html
@@ -161,7 +161,7 @@
                 <td class="top aligned">
                     <div class="ui input compact cooldown-input">
                         <input autocomplete="off" form="form-{{ playsound.name }}" type="number" name="cooldown"
-                               value="{{ playsound.cooldown if playsound.cooldown }}">
+                               value="{{ playsound.cooldown if playsound.cooldown is not none }}">
                     </div>
                 </td>
                 <td class="top aligned">

--- a/templates/admin/playsounds.html
+++ b/templates/admin/playsounds.html
@@ -161,7 +161,7 @@
                 <td class="top aligned">
                     <div class="ui input compact cooldown-input">
                         <input autocomplete="off" form="form-{{ playsound.name }}" type="number" name="cooldown"
-                               value="{{ playsound.cooldown }}">
+                               value="{{ playsound.cooldown if playsound.cooldown }}">
                     </div>
                 </td>
                 <td class="top aligned">


### PR DESCRIPTION
Instead of not adding anything, jinja2 adds 'None' if the cooldown was None which led to warnings in the browser


Pull request checklist:

- [X] `CHANGELOG.md` was updated, if applicable

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
