### PR TITLE
Fixed emote positioning showing scrollbar on CLR (#832)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## Unversioned
 
 - Minor: You can now allow users with level 420 to use the `!runpnsl` command (could only be set as low as 500 before). Default level requirement remains at 750. (#830)
+- Minor: Enlarged emotes on the CLR are no longer blurry
 - Bugfix: Fixed warnings in the admin playsounds page
+- Bugfix: Fixed scrollbar appearing on CLR overlay (#832)
 
 ## v1.43
 

--- a/static/css/clr.overlay.scss
+++ b/static/css/clr.overlay.scss
@@ -53,8 +53,14 @@ div.exploding {
   position: absolute;
 }
 
-img.absemote {
-  position: absolute;
+div.absemote_container {
+  position: fixed;
+  transform: translate(-50%, -50%);
+}
+
+img.absemote,
+#emote_combo img {
+  image-rendering: pixelated;
 }
 
 div.notifications {

--- a/static/scripts/clr.overlay.js
+++ b/static/scripts/clr.overlay.js
@@ -63,32 +63,39 @@ function add_emotes({
         // largest URL available
         let { url, needsScale } = getEmoteURL(emote);
 
-        let divsize = 120;
-        let posx = (Math.random() * ($(document).width() - divsize)).toFixed();
-        let posy = (Math.random() * ($(document).height() - divsize)).toFixed();
-        let newdiv = $('<img class="absemote">').css({
-            left: posx + 'px',
-            top: posy + 'px',
-            opacity: 0,
-            transform: `scale(${(emoteScale / 100) * needsScale})`,
-        });
-        newdiv.attr({ src: url });
-        newdiv.appendTo('body');
-        newdiv.animate(
+        let posX = `${Math.random() * 100}%`;
+        let posY = `${Math.random() * 100}%`;
+
+        let imgElement = $('<img class="absemote">')
+            .css({
+                transform: `scale(${(emoteScale / 100) * needsScale})`,
+            })
+            .attr({ src: url });
+
+        let containerDiv = $('<div class="absemote_container"></div>')
+            .css({
+                left: posX,
+                top: posY,
+                opacity: 0,
+            })
+            .append(imgElement)
+            .appendTo('body');
+
+        containerDiv.animate(
             {
                 opacity: opacity / 100,
             },
             500
         );
         setTimeout(() => {
-            newdiv.animate(
+            containerDiv.animate(
                 {
                     opacity: 0,
                 },
                 1000
             );
             setTimeout(() => {
-                newdiv.remove();
+                containerDiv.remove();
             }, 1000);
         }, persistenceTime);
     }


### PR DESCRIPTION
- Also, emotes can now take any spot on the CLR (Previously they could not go right to or slightly over the edges of the screen)
- Also includes a small change to change the image upscaling algorithm to "pixelated" instead of "auto", i.e. when emotes are zoomed in, the borders between pixels will not be smoothed out

Fixes #832 

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
