### PR TITLE
Semantic ui dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: Added a default dark theme to the bot website
 - Minor: Added timeout reason customization to various moderation modules
 - Minor: Added new module for simple emote spam moderation
 - Minor: You can now allow users with level 420 to use the `!runpnsl` command (could only be set as low as 500 before). Default level requirement remains at 750. (#830)

--- a/static/css/base.scss
+++ b/static/css/base.scss
@@ -506,3 +506,23 @@ select {
   color: white !important;
   border-color: rgba(255, 255, 255, 0.1) !important;
 }
+
+.chat.border {
+  border: none !important;
+}
+
+.div.chat {
+  border: none !important;
+}
+
+.chat:nth-child(odd) .chat-message.say,
+.chat:nth-child(odd) .chat-message.me {
+  background-color: #222222 !important;
+  color: white !important;
+}
+
+.chat:nth-child(even) .chat-message.say,
+.chat:nth-child(even) .chat-message.me {
+  background-color: #191919 !important;
+  color: white !important;
+}

--- a/static/css/base.scss
+++ b/static/css/base.scss
@@ -493,3 +493,7 @@ p {
   box-shadow: none;
   border-radius: none;
 }
+
+.ui.styled.accordion {
+  box-shadow: none;
+}

--- a/static/css/base.scss
+++ b/static/css/base.scss
@@ -1,11 +1,11 @@
 .pui.command,
 .pui.argument {
   font-family: monospace;
-  border-radius: 0.285rem;
-  background: #f8f8f9;
+  border-radius: none;
+  background: none;
   padding: 0.4em;
   line-height: 18px;
-  box-shadow: 0 0 0 1px rgba(34, 36, 38, 0.22) inset, 0 0 0 0 transparent;
+  box-shadow: none;
   display: inline-block;
 }
 
@@ -263,9 +263,8 @@ div.chat div.chat-message {
   word-break: break-word;
   word-wrap: break-word;
   color: #3d3d42;
-  border-bottom-color: #b4b4b4;
-  border-bottom-width: 1px;
-  border-bottom-style: solid;
+  border-bottom: 1px solid #1b1c1d;
+  border-right: 1px solid #1b1c1d;
   display: block;
   font-size: 12px;
   padding-bottom: 3px;
@@ -280,12 +279,14 @@ div.chat div.chat-message {
 
 .chat:nth-child(even) .chat-message.say,
 .chat:nth-child(even) .chat-message.me {
-  background-color: #c8c8c8;
+  background-color: #282828;
+  color: white;
 }
 
 .chat:nth-child(odd) .chat-message.say,
 .chat:nth-child(odd) .chat-message.me {
-  background-color: #d9d9d9;
+  background-color: #343434;
+  color: white;
 }
 
 .chat .chat-message.me.from-bot .message {
@@ -305,7 +306,7 @@ div.chat div.chat-message {
 }
 
 .chat.border {
-  border-color: #b4b4b4;
+  border-color: #1b1c1d;
   border-width: 0.666667px;
   border-style: solid;
   width: 341px;
@@ -487,13 +488,6 @@ p {
   padding-bottom: 16px !important;
 }
 
-.pui.command,
-.pui.argument {
-  background: none;
-  box-shadow: none;
-  border-radius: none;
-}
-
 .ui.styled.accordion {
   box-shadow: none;
 }
@@ -505,20 +499,4 @@ select {
   background-color: #2d2d2d !important;
   color: white !important;
   border-color: rgba(255, 255, 255, 0.1) !important;
-}
-
-.div.chat {
-  border: none !important;
-}
-
-.chat:nth-child(odd) .chat-message.say,
-.chat:nth-child(odd) .chat-message.me {
-  background-color: #343434 !important;
-  color: white !important;
-}
-
-.chat:nth-child(even) .chat-message.say,
-.chat:nth-child(even) .chat-message.me {
-  background-color: #282828 !important;
-  color: white !important;
 }

--- a/static/css/base.scss
+++ b/static/css/base.scss
@@ -500,7 +500,7 @@ p {
 
 input[type="text"],
 input[type="number"],
-input[type="link"],
+input[type="url"],
 select {
   background-color: #2d2d2d !important;
   color: white !important;

--- a/static/css/base.scss
+++ b/static/css/base.scss
@@ -439,7 +439,12 @@ img.emote {
   background-color: #2d2d2d;
 }
 
-h1, h2, h3, h4, h5, p {
+h1,
+h2,
+h3,
+h4,
+h5,
+p {
   color: white;
 }
 
@@ -470,4 +475,21 @@ h1, h2, h3, h4, h5, p {
 
 .ui.segment.help {
   display: none !important;
+}
+
+.ui.modal > .header,
+.ui.modal > .content,
+.ui.modal > .actions {
+  background: #2d2d2d;
+}
+
+.ui.button:not(.icon) > .icon:not(.button):not(.dropdown) {
+  padding-bottom: 16px !important;
+}
+
+.pui.command,
+.pui.argument {
+  background: none;
+  box-shadow: none;
+  border-radius: none;
 }

--- a/static/css/base.scss
+++ b/static/css/base.scss
@@ -279,13 +279,13 @@ div.chat div.chat-message {
 
 .chat:nth-child(even) .chat-message.say,
 .chat:nth-child(even) .chat-message.me {
-  background-color: #282828;
+  background-color: #0e0e0e;
   color: white;
 }
 
 .chat:nth-child(odd) .chat-message.say,
 .chat:nth-child(odd) .chat-message.me {
-  background-color: #343434;
+  background-color: #1a1a1a;
   color: white;
 }
 
@@ -318,12 +318,12 @@ div.chat div.chat-message {
 }
 
 .chat .user {
-  color: #BB4646;
+  color: #bb4646;
   font-weight: 700;
 }
 
 .chat .bot {
-  color: #6B78FF;
+  color: #6b78ff;
   font-weight: 700;
 }
 

--- a/static/css/base.scss
+++ b/static/css/base.scss
@@ -497,3 +497,11 @@ p {
 .ui.styled.accordion {
   box-shadow: none;
 }
+
+input[type="text"],
+input[type="number"],
+select {
+  background-color: #2d2d2d !important;
+  color: white !important;
+  border-color: rgba(255, 255, 255, 0.1) !important;
+}

--- a/static/css/base.scss
+++ b/static/css/base.scss
@@ -458,18 +458,18 @@ p {
 }
 
 .ui.compact.menu {
-  border-right: 1px solid rgba(255, 255, 255, .1) !important;
+  border-right: 1px solid rgba(255, 255, 255, 0.1) !important;
   border-radius: 0 !important;
 }
 
 .ui.tabular.menu .item:hover,
 .ui.tabular.menu .item {
-  color:white;
+  color: white;
 }
 
 .ui.table td.active,
 .ui.table tbody tr td.selectable:active {
-  background: rgba(255,255,255,.08) !important;
+  background: rgba(255, 255, 255, 0.08) !important;
   color: white !important;
 }
 

--- a/static/css/base.scss
+++ b/static/css/base.scss
@@ -399,6 +399,7 @@ span.winrate.positive {
 
 #commands div.segment.tab {
   min-height: 1024px;
+  background: #2d2d2d;
 }
 
 table .paginate div.pagination {
@@ -432,4 +433,41 @@ button.ui.button.streamelements {
 
 img.emote {
   height: 2em;
+}
+
+.main.container {
+  background-color: #2d2d2d;
+}
+
+h1, h2, h3, h4, h5, p {
+  color: white;
+}
+
+.ui.tabular.menu .active.item {
+  color: white;
+  background: #2d2d2d;
+}
+
+.ui.basic.table {
+  border: none;
+}
+
+.ui.compact.menu {
+  border-right: 1px solid rgba(255, 255, 255, .1) !important;
+  border-radius: 0 !important;
+}
+
+.ui.tabular.menu .item:hover,
+.ui.tabular.menu .item {
+  color:white;
+}
+
+.ui.table td.active,
+.ui.table tbody tr td.selectable:active {
+  background: rgba(255,255,255,.08) !important;
+  color: white !important;
+}
+
+.ui.segment.help {
+  display: none !important;
 }

--- a/static/css/base.scss
+++ b/static/css/base.scss
@@ -317,12 +317,12 @@ div.chat div.chat-message {
 }
 
 .chat .user {
-  color: #8b0000;
+  color: #BB4646;
   font-weight: 700;
 }
 
 .chat .bot {
-  color: #7878ff;
+  color: #6B78FF;
   font-weight: 700;
 }
 
@@ -507,22 +507,18 @@ select {
   border-color: rgba(255, 255, 255, 0.1) !important;
 }
 
-.chat.border {
-  border: none !important;
-}
-
 .div.chat {
   border: none !important;
 }
 
 .chat:nth-child(odd) .chat-message.say,
 .chat:nth-child(odd) .chat-message.me {
-  background-color: #222222 !important;
+  background-color: #343434 !important;
   color: white !important;
 }
 
 .chat:nth-child(even) .chat-message.say,
 .chat:nth-child(even) .chat-message.me {
-  background-color: #191919 !important;
+  background-color: #282828 !important;
   color: white !important;
 }

--- a/static/css/base.scss
+++ b/static/css/base.scss
@@ -500,6 +500,7 @@ p {
 
 input[type="text"],
 input[type="number"],
+input[type="link"],
 select {
   background-color: #2d2d2d !important;
   color: white !important;

--- a/static/scripts/admin/playsound.admin.js
+++ b/static/scripts/admin/playsound.admin.js
@@ -106,13 +106,13 @@ $(window).on('load', function() {
 
     function resultFeedback(success, text) {
         // reset state...
-        messageBox.removeClass('hidden positive negative');
+        messageBox.removeClass('hidden green red');
 
         // then update element.
         if (success) {
-            messageBox.addClass('positive');
+            messageBox.addClass('green');
         } else {
-            messageBox.addClass('negative');
+            messageBox.addClass('red');
         }
         messageText.text(text);
     }

--- a/static/scripts/commands.js
+++ b/static/scripts/commands.js
@@ -77,7 +77,8 @@ function handle_command(base_key, command) {
                 el_base.empty();
                 if (value.length > 0) {
                     var $accordion = $('<div>', {
-                        class: 'ui styled accordion examples',
+                        class: 'ui styled accordion examples inverted',
+                        style: 'background: #2d2d2d;',
                     });
                     el_base.append('<h5>Command examples</h5>');
                     el_base.append($accordion);

--- a/static/scripts/paginate.js
+++ b/static/scripts/paginate.js
@@ -138,7 +138,7 @@ function paginate(selector, limit, direction, action, on_success, show_ends) {
 
     /* Create menu base */
     paginate_el.append(
-        '<div class="ui right floated pagination menu"><a class="item nleft"><i class="left chevron icon"></i></a>' +
+        '<div class="ui right floated pagination menu inverted" style="background-color: #2d2d2d; color: white !important;"><a class="item nleft"><i class="left chevron icon"></i></a>' +
             buttons +
             '<a class="item nright"><i class="right chevron icon"></i></a></div>'
     );

--- a/static/scripts/playsound.common.js
+++ b/static/scripts/playsound.common.js
@@ -19,9 +19,9 @@ $(document).ready(function() {
                 }
 
                 playButtons.removeClass('disabled');
-                playButtons.addClass('positive');
+                playButtons.addClass('green');
 
-                stopButtons.removeClass('positive');
+                stopButtons.removeClass('green');
                 stopButtons.addClass('disabled');
             };
 
@@ -36,11 +36,11 @@ $(document).ready(function() {
 
             player.play();
 
-            playButtons.removeClass('positive');
+            playButtons.removeClass('green');
             playButtons.addClass('disabled');
 
             stopButton.removeClass('disabled');
-            stopButton.addClass('positive');
+            stopButton.addClass('green');
         });
 
         $(stopButton).click(() => {

--- a/templates/admin/banphrases.html
+++ b/templates/admin/banphrases.html
@@ -3,11 +3,11 @@
 {% block title %}Admin - Banphrases{% endblock %}
 {% block body %}
     <form action="/admin/banphrases/create" method="GET">
-        <button class="ui button green"><i class="icon add"></i> <strong>Create Banphrase</strong>
+        <button class="ui button green inverted"><i class="icon add"></i> <strong>Create Banphrase</strong>
         </button>
     </form>
     <h2>Banphrases</h2>
-    <table class="ui selectable table basic">
+    <table class="ui selectable table basic inverted">
         <thead>
         <tr>
             <th class="collapsing">ID</th>
@@ -55,8 +55,8 @@
             </div>
         </div>
         <div class="actions">
-            <div class="ui approve button">Remove</div>
-            <div class="ui cancel button">Cancel</div>
+            <div class="ui approve button inverted">Remove</div>
+            <div class="ui cancel button inverted">Cancel</div>
         </div>
     </div>
 {% endblock %}

--- a/templates/admin/banphrases.html
+++ b/templates/admin/banphrases.html
@@ -3,8 +3,7 @@
 {% block title %}Admin - Banphrases{% endblock %}
 {% block body %}
     <form action="/admin/banphrases/create" method="GET">
-        <button class="ui button green inverted"><i class="icon add"></i> <strong>Create Banphrase</strong>
-        </button>
+        <button class="ui button green inverted"><i class="icon add"></i> Create Banphrase</button>
     </form>
     <h2>Banphrases</h2>
     <table class="ui selectable table basic inverted">

--- a/templates/admin/banphrases.html
+++ b/templates/admin/banphrases.html
@@ -48,10 +48,10 @@
     </table>
     <div class="ui modal remove-banphrase">
         <i class="close icon"></i>
-        <div class="header">Confirm Action</div>
+        <div class="header"><p>Confirm Action</p></div>
         <div class="content">
             <div class="description">
-                Are you sure you want to remove this banphrase? This action is irreversible.
+                <p>Are you sure you want to remove this banphrase? This action is irreversible.</p>
             </div>
         </div>
         <div class="actions">

--- a/templates/admin/commands.html
+++ b/templates/admin/commands.html
@@ -13,7 +13,7 @@
     <div class="header">Your Command was edited successfully.</div>
 </div>
 {% endif %}
-<button class="ui button create-command green"><i class="icon add"></i> <strong>Create Command</strong></button>
+<button class="ui button create-command green inverted"><i class="icon add"></i> <strong>Create Command</strong></button>
 <h2>Commands</h2>
 <p>This is a list of all commands that you can edit.</p>
 <div id="commands">
@@ -27,7 +27,7 @@
     {% endif %}
 </div>
 <div class="ui bottom attached tab segment active" data-tab="custom">
-    <table class="ui selectable table">
+    <table class="ui selectable basic table inverted">
         <thead>
             <tr>
                 <th>Command</th>

--- a/templates/admin/commands.html
+++ b/templates/admin/commands.html
@@ -53,7 +53,7 @@
     </table>
 </div>
 <div class="ui bottom attached tab segment" data-tab="point">
-    <table class="ui selectable table">
+    <table class="ui selectable basic table inverted">
         <thead>
             <tr>
                 <th>Command</th>
@@ -82,7 +82,7 @@
     </table>
 </div>
 <div class="ui bottom attached tab segment" data-tab="moderator">
-    <table class="ui selectable table">
+    <table class="ui selectable basic table inverted">
         <thead>
             <tr>
                 <th>Command</th>
@@ -110,15 +110,15 @@
 </div>
 <div class="ui modal remove-command">
     <i class="close icon"></i>
-    <div class="header">Confirm Action</div>
+    <div class="header"><p>Confirm Action</p></div>
     <div class="content">
         <div class="description">
-            Are you sure you want to remove this command? This action is irreversible.
+            <p>Are you sure you want to remove this command? This action is irreversible.</p>
         </div>
     </div>
     <div class="actions">
-        <div class="ui approve button">Remove</div>
-        <div class="ui cancel button">Cancel</div>
+        <div class="ui approve inverted button">Remove</div>
+        <div class="ui cancel inverted button">Cancel</div>
     </div>
 </div>
 {% endblock %}

--- a/templates/admin/commands.html
+++ b/templates/admin/commands.html
@@ -13,7 +13,7 @@
     <div class="header">Your Command was edited successfully.</div>
 </div>
 {% endif %}
-<button class="ui button create-command green inverted"><i class="icon add"></i> <strong>Create Command</strong></button>
+<button class="ui button create-command green inverted"><i class="icon add"></i> Create Command</button>
 <h2>Commands</h2>
 <p>This is a list of all commands that you can edit.</p>
 <div id="commands">

--- a/templates/admin/configure_module.html
+++ b/templates/admin/configure_module.html
@@ -16,7 +16,7 @@
 <div class="ui divider"></div>
 {% if sub_modules|length > 0 %}
 <h3>Sub-modules</h3>
-    <table class="ui very basic table collapsing">
+    <table class="ui very basic table collapsing inverted">
         <thead>
             <tr>
                 <th class="collapsing">Module</th>
@@ -38,8 +38,8 @@
                         </div>
                     {% endif %}
                 </td>
-                <td class="right aligned collapsing">
-                <button class="ui compact button edit-row"><i class="icon setting"></i>Configure</button></td>
+                <td class="right aligned collapsing inverted">
+                <button class="ui compact button inverted edit-row"><i class="icon setting"></i>Configure</button></td>
             </tr>
 {% endfor %}
         </tbody>
@@ -47,7 +47,7 @@
     {% endif %}
     <h3>Settings</h3>
 {% if module.SETTINGS|length > 0 %}
-<form class="ui form" method="POST" action="/admin/modules/edit/{{ module.ID }}">
+<form class="ui form inverted" method="POST" action="/admin/modules/edit/{{ module.ID }}">
     {%- for setting in module.SETTINGS %}
     <div class="{{ 'required' if setting.required else ''}} {{ 'inline' if setting.type in ['boolean'] else '' }} field eight wide">
         <label for="key_{{ setting.key }}">{{ setting.label }}</label>
@@ -73,7 +73,7 @@
     {% endfor -%}
     <div class="ui message warning" style="padding: 0.4em;"></div>
     <div class="ui message error" style="padding: 0.4em;"></div>
-    <div class="ui submit button green"><i class="icon setting"></i>Configure</div>
+    <div class="ui submit button green inverted"><i class="icon setting"></i>Save</div>
 </div>
 </form>
 {% else %}

--- a/templates/admin/create_banphrase.html
+++ b/templates/admin/create_banphrase.html
@@ -7,7 +7,7 @@
 {% else %}
 <h2>Create Banphrase</h2>
 {% endif %}
-<form class="ui form" method="POST" action="/admin/banphrases/create">
+<form class="ui form inverted" method="POST" action="/admin/banphrases/create">
     {% if banphrase %}
     <input type="hidden" name="id" value="{{ banphrase.id }}" />
     {% endif %}
@@ -86,9 +86,9 @@
     <div class="ui message warning" style="padding: 0.4em;"></div>
     <div class="ui message error" style="padding: 0.4em;"></div>
     {% if banphrase %}
-    <div class="ui submit button green">Edit</div>
+    <div class="ui submit button green inverted">Save</div>
     {% else %}
-    <div class="ui submit button green">Create</div>
+    <div class="ui submit button green inverted">Create</div>
     {% endif %}
 </div>
 </form>

--- a/templates/admin/create_banphrase.html
+++ b/templates/admin/create_banphrase.html
@@ -13,18 +13,30 @@
     {% endif %}
     <div class="fields">
         <div class="required field four wide">
-            <label>Name</label>
-            <input type="text" name="name" placeholder="Name to describe Banphrase" value="{{ banphrase.name if banphrase else ''}}" />
+            <div class="ui form">
+                <div class="required field">
+                    <label>Name</label>
+                    <input type="text" name="name" placeholder="Name to describe banphrase" value="{{ banphrase.name if banphrase else ''}}"/>
+                </div>
+            </div>
         </div>
         <div class="required field twelve wide">
-            <label>Banned phrase</label>
-            <input type="text" name="phrase" placeholder="Banned phrase" value="{{ banphrase.phrase if banphrase else ''}}"/>
+            <div class="ui form">
+                <div class="required field">
+                    <label>Banned Phrase</label>
+                    <input type="text" name="phrase" placeholder="Banned phrase" value="{{ banphrase.phrase if banphrase else ''}}"/>
+                </div>
+            </div>
         </div>
     </div>
     <div class="fields">
         <div class="field ui four wide required">
-            <label>Timeout duration</label>
-            <input type="number" name="length" placeholder="Timeout duration" value="{{ banphrase.length if banphrase else '300'}}"/>
+            <div class="ui form">
+                <div class="required field">
+                    <label>Timeout Duration</label>
+                    <input type="number" name="length" placeholder="Timeout duration" value="{{ banphrase.length if banphrase else '300'}}"/>
+                </div>
+            </div>
         </div>
         <div class="field ui four wide required">
             <label>Operator</label>

--- a/templates/admin/create_command.html
+++ b/templates/admin/create_command.html
@@ -3,7 +3,7 @@
 {% block title %}Create Command{% endblock %}
 {% block body %}
 <h2>Create Command</h2>
-<form class="ui form" method="POST">
+<form class="ui form inverted" method="POST">
     <div class="fields">
         <div class="required field field-alias four wide">
             <label>Aliases</label>
@@ -49,7 +49,7 @@
     </div>
     <div class="ui message warning" style="padding: 0.4em;"></div>
     <div class="ui message error" style="padding: 0.4em;"></div>
-    <div class="ui submit button green">Create</div>
+    <div class="ui submit button green inverted">Create</div>
 </div>
 </form>
 {% endblock %}

--- a/templates/admin/create_timer.html
+++ b/templates/admin/create_timer.html
@@ -8,7 +8,7 @@
 <h2>Create Timer</h2>
 {% endif %}
 <p>An interval set to 0 means it will not be run.</p>
-<form class="ui form" method="POST" action="/admin/timers/create">
+<form class="ui form inverted" method="POST" action="/admin/timers/create">
     {% if timer %}
     <input type="hidden" name="id" value="{{ timer.id }}" />
     {% endif %}
@@ -42,9 +42,9 @@
     <div class="ui message warning" style="padding: 0.4em;"></div>
     <div class="ui message error" style="padding: 0.4em;"></div>
     {% if timer %}
-    <div class="ui submit button green">Edit</div>
+    <div class="ui submit button green inverted">Save</div>
     {% else %}
-    <div class="ui submit button green">Create</div>
+    <div class="ui submit button green inverted">Create</div>
     {% endif %}
 </div>
 </form>

--- a/templates/admin/edit_command.html
+++ b/templates/admin/edit_command.html
@@ -16,7 +16,7 @@
 <p>Columns in yellow mark an unsaved change.</p>
 <p>Click the "Save Changes" button below to confirm your changes.</p>
 <h2>Command</h2>
-<table class="ui definition table editcommand celled command inverted">
+<table class="ui very basic table editcommand celled command inverted">
     <tbody>
         {% for label, editable, value, name, type, suffix in data_available %}
         {% if type == 'boolean' %}
@@ -27,7 +27,7 @@
             <td class="buttons two wide right aligned">
                 {% if editable %}
                 <div class="ui small compact basic icon buttons display">
-                    <button title="Edit value" class="ui button icon edit"><i class="icon edit"></i></button>
+                    <button title="Edit value" class="ui button icon edit"><i class="icon edit outline"></i></button>
                 </div>
                 <div class="ui small compact basic icon buttons edit">
                     <button title="Cancel changes" class="ui button icon cancel"><i class="icon red cancel"></i></button>
@@ -78,7 +78,7 @@
 ] %}
 {% endif %}
 <h2>Action</h2>
-<table class="ui definition table editcommand celled action inverted">
+<table class="ui very basic table editcommand celled action inverted">
     <tbody>
         {% for label, editable, value, name, type, suffix in data_available %}
         {% if type == 'boolean' %}

--- a/templates/admin/edit_command.html
+++ b/templates/admin/edit_command.html
@@ -16,7 +16,7 @@
 <p>Columns in yellow mark an unsaved change.</p>
 <p>Click the "Save Changes" button below to confirm your changes.</p>
 <h2>Command</h2>
-<table class="ui definition table editcommand celled command">
+<table class="ui definition table editcommand celled command inverted">
     <tbody>
         {% for label, editable, value, name, type, suffix in data_available %}
         {% if type == 'boolean' %}
@@ -78,7 +78,7 @@
 ] %}
 {% endif %}
 <h2>Action</h2>
-<table class="ui definition table editcommand celled action">
+<table class="ui definition table editcommand celled action inverted">
     <tbody>
         {% for label, editable, value, name, type, suffix in data_available %}
         {% if type == 'boolean' %}
@@ -92,7 +92,7 @@
             <td class="buttons two wide right aligned">
                 {% if editable %}
                 <div class="ui small compact basic icon buttons display">
-                    <button title="Edit value" class="ui button icon edit"><i class="icon edit"></i></button>
+                    <button title="Edit value" class="ui button icon edit"><i class="icon edit outline"></i></button>
                 </div>
                 <div class="ui small compact basic icon buttons edit">
                     <button title="Cancel changes" class="ui button icon cancel"><i class="icon red cancel"></i></button>

--- a/templates/admin/edit_command.html
+++ b/templates/admin/edit_command.html
@@ -142,7 +142,7 @@
 </table>
 
 {% if user.level >= command.level %}
-<button class="ui disabled button large green icon save-changes"><i class="icon save"></i> <strong>Save Changes</strong></button>
+<button class="ui disabled button large green icon save-changes inverted"><i class="icon save"></i> <strong>Save Changes</strong></button>
 {% else %}
 <p>You cannot modify this command, because your level is too low.</p>
 {% endif %}

--- a/templates/admin/helper/command_action.html
+++ b/templates/admin/helper/command_action.html
@@ -1,1 +1,1 @@
-<td class="right aligned collapsing"><button class="ui compact button remove-command" data-id="{{ command.id }}"><i class="icon red remove"></i>Remove</button><button class="ui compact button edit-command" data-id="{{ command.id }}"><i class="icon edit"></i>Edit</button></td>
+<td class="right aligned collapsing"><button class="ui compact button remove-command inverted" data-id="{{ command.id }}"><i class="icon red remove"></i>Remove</button><button class="ui compact button edit-command inverted" data-id="{{ command.id }}"><i class="icon edit"></i>Edit</button></td>

--- a/templates/admin/helper/row_action.html
+++ b/templates/admin/helper/row_action.html
@@ -1,3 +1,3 @@
 <td class="right aligned collapsing"><div class="ui toggle checkbox"><input type="checkbox" name="public" class="toggle-row" {{ 'checked="checked"' if row.enabled else '' }}><label></label></div></td>
 <td class="right aligned collapsing">
-<button class="ui compact button remove-row"><i class="icon red remove"></i>Remove</button><button class="ui compact button edit-row"><i class="icon edit"></i>Edit</button></td>
+<button class="ui compact button remove-row inverted"><i class="icon red remove"></i>Remove</button><button class="ui compact button edit-row inverted"><i class="icon edit"></i>Edit</button></td>

--- a/templates/admin/home.html
+++ b/templates/admin/home.html
@@ -3,7 +3,7 @@
 {% block title %}Admin - Home{% endblock %}
 {% block body %}
 <h2>Admin Zone</h2>
-Use the links in the menu to browse admin-only sites.
+<p>Use the links in the menu to browse admin-only sites.</p>
 
 {% include 'admin/twitter.html' %}
 {% include 'admin/logs.html' %}
@@ -27,7 +27,7 @@ function on_success(response, key)
             var $action_td = $('<td>');
 {%- if not session.user.level or session.user.level >= 1000 %}
             var $unfollow_btn = $('<button>', {
-                class: 'ui button',
+                class: 'ui button inverted',
             }).html('<i class="icon minus red"></i>Unfollow');
             $unfollow_btn.api({
                 action: 'twitter_unfollow',

--- a/templates/admin/layout.html
+++ b/templates/admin/layout.html
@@ -15,7 +15,7 @@
                 <div class="ui simple dropdown item">{{ menuitem.caption }}<i class="dropdown icon"></i>
                     <div class="menu">
                         {%- for submenuitem in menuitem.href %}
-                            <a class="inverted item{% if submenuitem.id == active_page %} active{% endif %}" href="{{ submenuitem.href }}">
+                            <a class="item{% if submenuitem.id == active_page %} active{% endif %}" href="{{ submenuitem.href }}" style="background-color: #1b1c1d !important; color: white !important;">
                             {{ submenuitem.caption }}</a>
                         {% endfor -%}
                     </div>

--- a/templates/admin/layout.html
+++ b/templates/admin/layout.html
@@ -1,21 +1,21 @@
 {% extends "layout.html" %}
 {% block menu %}
-    <div class="ui top fixed menu inverted blue">
+    <div class="ui top fixed menu inverted">
         <div class="menu" style="margin:auto;">
         {% for menuitem in nav_bar_admin_header %}
         {%- if not session.user or session.user.level > menuitem.level %}
             {%- if menuitem.id %}
-            <a class="inverted blue item{%- if menuitem.id == active_page %} active{% endif -%}" href="{{ menuitem.href }}">
+            <a class="inverted item{%- if menuitem.id == active_page %} active{% endif -%}" href="{{ menuitem.href }}">
                 {%- if menuitem.id == 'home' %}
                 <img class="logo" src="/static/images/logo_{{ streamer.full_name }}_tn.png" alt="{{ streamer.name }} logo"/>
                 {% endif -%}
                 {{ menuitem.caption }}</a>
             {%- else %}
-            <div class="ui compact menu inverted blue">
+            <div class="ui compact menu inverted">
                 <div class="ui simple dropdown item">{{ menuitem.caption }}<i class="dropdown icon"></i>
                     <div class="menu">
                         {%- for submenuitem in menuitem.href %}
-                            <a class="inverted blue item{% if submenuitem.id == active_page %} active{% endif %}" href="{{ submenuitem.href }}">
+                            <a class="inverted item{% if submenuitem.id == active_page %} active{% endif %}" href="{{ submenuitem.href }}">
                             {{ submenuitem.caption }}</a>
                         {% endfor -%}
                     </div>

--- a/templates/admin/links_blacklist.html
+++ b/templates/admin/links_blacklist.html
@@ -3,7 +3,7 @@
 {% block title %}Admin - Blacklisted Links{% endblock %}
 {% block body %}
 <h2>Blacklisted Links</h2>
-<table class="ui table basic">
+<table class="ui table basic inverted">
     <thead>
         <tr>
             <th>ID</th>

--- a/templates/admin/links_whitelist.html
+++ b/templates/admin/links_whitelist.html
@@ -3,7 +3,7 @@
 {% block title %}Admin - Whitelisted Links{% endblock %}
 {% block body %}
 <h2>Whitelisted Links</h2>
-<table class="ui table basic">
+<table class="ui table basic inverted">
     <thead>
         <tr>
             <th>ID</th>

--- a/templates/admin/logs.html
+++ b/templates/admin/logs.html
@@ -1,5 +1,5 @@
 <h4>Admin Logs</h4>
-<table class="ui table collapsing">
+<table class="ui basic table collapsing inverted">
     <thead>
         <tr>
             <th>Admin</th>

--- a/templates/admin/moderators.html
+++ b/templates/admin/moderators.html
@@ -4,7 +4,7 @@
 {% block body %}
 <h2>Bot Moderators</h2>
 <div id="bot_moderators">
-    <table class="ui very basic table collapsing">
+    <table class="ui very basic table collapsing inverted">
 {% for title, users in userlists.items() %}
 {% if users|length > 0 %}
         <thead>

--- a/templates/admin/modules.html
+++ b/templates/admin/modules.html
@@ -4,7 +4,7 @@
 {% block body %}
 <h2>Modules</h2>
 <div id="modules">
-    <table class="ui sortable very basic table collapsing">
+    <table class="ui sortable very basic table collapsing inverted">
         <thead>
             <tr>
                 <th class="collapsing">Module</th>
@@ -29,7 +29,7 @@
                     {% endif %}
                 </td>
                 <td class="right aligned collapsing">
-                <button class="ui compact button edit-row" {{- 'disabled' if session.user.level < row.CONFIGURE_LEVEL else '' -}}><i class="icon setting"></i>Configure</button></td>
+                <button class="ui compact button edit-row inverted" {{- 'disabled' if session.user.level < row.CONFIGURE_LEVEL else '' -}}><i class="icon setting"></i>Configure</button></td>
             </tr>
 {% endfor %}
         </tbody>

--- a/templates/admin/playsounds.html
+++ b/templates/admin/playsounds.html
@@ -64,7 +64,7 @@
         </div>
     </div>
 
-    <div class="ui icon {{ "positive" if playsounds_enabled else "negative" }} message">
+    <div class="ui icon {{ "positive" if playsounds_enabled else "negative" }} inverted message">
         <i class="{{ "check circle" if playsounds_enabled else "exclamation triangle" }} icon"></i>
         <div class="content">
             <div class="header">
@@ -82,7 +82,7 @@
             <div class="ui toggle checkbox">
                 <input id="toggle-module-checkbox" type="checkbox" autocomplete="off" {% if playsounds_enabled %}
                        checked {% endif %}>
-                <label>Enable Playsound module</label>
+                <label><p>Enable Playsound module</p></label>
             </div>
             </p>
         </div>
@@ -104,7 +104,7 @@
             </form>
         </div>
     </div>
-    <table class="ui compact table">
+    <table class="ui compact very basic table inverted">
         <thead>
         <tr>
             <th class="collapsing">Name</th>

--- a/templates/admin/playsounds.html
+++ b/templates/admin/playsounds.html
@@ -4,7 +4,7 @@
 {% block body %}
     <h2>Playsounds</h2>
 
-    <div class="ui icon message">
+    <div class="ui icon message inverted">
         <i class="info circle icon"></i>
         <div class="content">
             <div class="header">
@@ -12,7 +12,7 @@
             </div>
             <p>The playsound feature allows viewers to play predefined soundbites on stream.</p>
 
-            <div class="ui raised segment">
+            <div class="ui raised segment inverted">
                 <p>
                     Playing a sound
                     {% if module_settings.point_cost <= 0 and module_settings.token_cost <= 0 %}
@@ -100,11 +100,11 @@
                 <input autocomplete="off" type="url" name="link" class="link-input middle-input"
                        placeholder="New playsound link"
                        style="width: 300px;" required>
-                <button class="ui button positive" id="#create-playsound-button" type="submit">Create Playsound</button>
+                <button class="ui button green inverted" id="#create-playsound-button" type="submit">Create Playsound</button>
             </form>
         </div>
     </div>
-    <table class="ui compact very basic table inverted">
+    <table class="ui single line very basic table inverted">
         <thead>
         <tr>
             <th class="collapsing">Name</th>
@@ -136,35 +136,37 @@
                                  data-name="{{ playsound.name }}"
                                  data-link="{{ playsound.link }}"
                                  data-volume="{{ playsound.volume }}">
-                                <button class="positive play-in-browser-play ui icon button compact">
+                                <button class="green inverted play-in-browser-play ui icon button compact">
                                     <i class="play circle outline icon"></i>
                                     Test in browser
                                 </button>
-                                <button class="play-in-browser-stop ui button compact icon disabled">
-                                    <i class="stop circle outline icon"></i>Stop Playback
+                                <button class="play-in-browser-stop ui button compact icon disabled inverted">
+                                    <i class="stop circle outline icon"></i>
+                                    Stop Playback
                                 </button>
-                                <button class="play-on-stream ui button icon compact">
-                                    <i class="play circle outline icon"></i>Test on stream
+                                <button class="play-on-stream ui button icon compact inverted">
+                                    <i class="play circle outline icon"></i>
+                                    Test on stream
                                 </button>
                             </div>
                         </div>
                     </div>
 
                 </td>
-                <td class="top aligned">
+                <td class="middle aligned">
                     <div class="min-height-container volume-container">
                         <input form="form-{{ playsound.name }}" type="hidden" name="volume">
-                        <div class="ui range volume-slider" data-initial="{{ playsound.volume }}"></div>
+                        <div class="ui range volume-slider inverted" data-initial="{{ playsound.volume }}"></div>
                         <div class="volume-label">{{ playsound.volume }}</div>
                     </div>
                 </td>
-                <td class="top aligned">
+                <td class="middle aligned">
                     <div class="ui input compact cooldown-input">
                         <input autocomplete="off" form="form-{{ playsound.name }}" type="number" name="cooldown"
                                value="{{ playsound.cooldown if playsound.cooldown is not none }}">
                     </div>
                 </td>
-                <td class="top aligned">
+                <td class="middle aligned">
                     <div class="min-height-container">
                         <div class="ui toggle fitted checkbox enabled-input">
                             <input autocomplete="off" form="form-{{ playsound.name }}" type="checkbox"
@@ -176,10 +178,10 @@
                 <td>
                     <div class="actions-buttons-container">
                         <button form="form-{{ playsound.name }}"
-                                class="playsound-submit-save ui compact positive button" type="submit">Save
+                                class="playsound-submit-save ui compact green inverted button" type="submit">Save
                         </button>
                         <button form="form-{{ playsound.name }}"
-                                class="playsound-submit-delete ui compact negative button" type="button">Delete
+                                class="playsound-submit-delete ui compact red inverted button" type="button">Delete
                         </button>
                     </div>
                 </td>
@@ -190,16 +192,17 @@
 
     <div class="ui tiny test modal" id="delete-modal">
         <div class="header">
-            Delete Playsound
+            <p>Delete Playsound</p>
         </div>
         <div class="content">
             <p>Please confirm you want to delete that playsound. This action is irreversible.</p>
         </div>
         <div class="actions">
-            <div class="ui negative button">
+            <div class="ui red inverted right labeled icon button">
                 No, Don't delete
+                <i class="close icon"></i>
             </div>
-            <div class="ui positive right labeled icon button">
+            <div class="ui green inverted right labeled icon button">
                 Yes, delete
                 <i class="checkmark icon"></i>
             </div>
@@ -208,7 +211,7 @@
 
 {% endblock %}
 {% block footer %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/howler/2.1.2/howler.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/howler/2.1.3/howler.min.js"></script>
     {% assets 'base_js', 'range_slider_js', 'playsound_common_js', 'playsound_admin_js' %}
         <script type="text/javascript" src="{{ ASSET_URL }}"></script>
     {% endassets %}

--- a/templates/admin/streamer.html
+++ b/templates/admin/streamer.html
@@ -3,8 +3,8 @@
 {% block title %}Admin - Streamer Info{% endblock %}
 {% block body %}
 <h2>Streamer Info</h2>
-Use the links in the menu to browse admin-only sites.
-<table class="social ui single line table collapsing">
+<p>Use the links in the menu to browse admin-only sites.</p>
+<table class="social ui single line very basic table collapsing inverted">
     <thead>
         <tr>
             <th></th><th></th><th>Preview</th>

--- a/templates/admin/timers.html
+++ b/templates/admin/timers.html
@@ -13,9 +13,9 @@
     <div class="header">Your Timer was edited successfully.</div>
 </div>
 {% endif %}
-<button class="ui button create-timer green"><i class="icon add"></i> <strong>Create Timer</strong></button>
+<button class="ui button create-timer green inverted"><i class="icon add"></i> <strong>Create Timer</strong></button>
 <h2>Timers</h2>
-<table class="ui table basic">
+<table class="ui table very basic inverted">
     <thead>
         <tr>
             <th class="collapsing">Name</th>

--- a/templates/admin/timers.html
+++ b/templates/admin/timers.html
@@ -13,7 +13,7 @@
     <div class="header">Your Timer was edited successfully.</div>
 </div>
 {% endif %}
-<button class="ui button create-timer green inverted"><i class="icon add"></i> <strong>Create Timer</strong></button>
+<button class="ui button create-timer green inverted"><i class="icon add"></i> Create Timer</button>
 <h2>Timers</h2>
 <table class="ui table very basic inverted">
     <thead>

--- a/templates/admin/timers.html
+++ b/templates/admin/timers.html
@@ -40,15 +40,15 @@
 </table>
 <div class="ui modal remove-timer">
     <i class="close icon"></i>
-    <div class="header">Confirm Action</div>
+    <div class="header"><p>Confirm Action</p></div>
     <div class="content">
         <div class="description">
-            Are you sure you want to remove this timer? This action is irreversible.
+            <p>Are you sure you want to remove this timer? This action is irreversible.</p>
         </div>
     </div>
     <div class="actions">
-        <div class="ui approve button">Remove</div>
-        <div class="ui cancel button">Cancel</div>
+        <div class="ui approve inverted button">Remove</div>
+        <div class="ui cancel inverted button">Cancel</div>
     </div>
 </div>
 {% endblock %}

--- a/templates/admin/twitter.html
+++ b/templates/admin/twitter.html
@@ -2,7 +2,7 @@
 {%- if not session.user.level or session.user.level >= 1000 %}
 <div class="twitter-follow">
 <div class="ui left icon action input">
-    <i class="icon twitter"></i><input type="text" placeholder="Twitter Username"><button class="ui button inverted"><i class="icon add green"></i>Follow</button>
+    <i class="icon twitter inverted"></i><input type="text" placeholder="Twitter Username"><button class="ui button inverted"><i class="icon add green"></i>Follow</button>
 </div>
 </div>
 {% endif -%}

--- a/templates/admin/twitter.html
+++ b/templates/admin/twitter.html
@@ -2,10 +2,10 @@
 {%- if not session.user.level or session.user.level >= 1000 %}
 <div class="twitter-follow">
 <div class="ui input"><input type="text"></div>
-<button class="ui button"><i class="icon add green"> </i>Follow</button>
+<button class="ui button inverted"><i class="icon add green"> </i>Follow</button>
 </div>
 {% endif -%}
-<table class="ui celled table selectable twitter_follows paginate_base">
+<table class="ui celled basic table selectable twitter_follows paginate_base inverted">
     <thead>
         <tr>
             <th>Username</th>

--- a/templates/admin/twitter.html
+++ b/templates/admin/twitter.html
@@ -1,8 +1,9 @@
 <h4>Twitter</h4>
 {%- if not session.user.level or session.user.level >= 1000 %}
 <div class="twitter-follow">
-<div class="ui input"><input type="text"></div>
-<button class="ui button inverted"><i class="icon add green"> </i>Follow</button>
+<div class="ui left icon action input">
+    <i class="icon twitter"></i><input type="text" placeholder="Twitter Username"><button class="ui button inverted"><i class="icon add green"></i>Follow</button>
+</div>
 </div>
 {% endif -%}
 <table class="ui celled basic table selectable twitter_follows paginate_base inverted">

--- a/templates/command_detailed.html
+++ b/templates/command_detailed.html
@@ -10,15 +10,15 @@
 </p>
 {% endif %}
 {% if examples|length > 0 %}
-<div class="ui styled accordion examples">
+<div class="ui styled accordion examples inverted" style="background: #2d2d2d;">
     {% set index = 1 %}
     {% for example in examples -%}
     <div class="title{{ ' active' if index == 1 else '' }}">
         <i class="dropdown icon"></i>{{ example['title'] }}
     </div>
-    <div class="content{{ ' active' if index == 1 else '' }}">
+    <div class="content{{ ' active' if index == 1 else '' }}" style="background: #2d2d2d;">
         {% if example['description']|length > 0 %}
-        <div class="description autolink">{{ example['description'] }}</div>
+        <div class="description autolink"><p>{{ example['description'] }}</p></div>
         {% endif %}
         {% for chat_message in example['messages'] -%}
         {% include 'helper/command_chat_message.html' %}

--- a/templates/commands.html
+++ b/templates/commands.html
@@ -18,7 +18,7 @@
         <div class="column four wide">
             {% set base_key = 'c1' %}
             <div class="commandlist-container {{ base_key }}">
-            <table class="ui table collapsed collapsing commandlist {{ base_key }}" data-key="{{ base_key }}">
+            <table class="ui basic table collapsed collapsing commandlist inverted {{ base_key }}" data-key="{{ base_key }}">
                 <thead>
                     <tr>
                         <th>Command trigger</th>
@@ -42,7 +42,7 @@
         <div class="column four wide">
             {% set base_key = 'c2' %}
             <div class="commandlist-container {{ base_key }}">
-            <table class="ui table collapsed collapsing commandlist {{ base_key }}" data-key="{{ base_key }}">
+            <table class="ui basic table collapsed collapsing commandlist inverted {{ base_key }}" data-key="{{ base_key }}">
                 <thead>
                     <tr>
                         <th>Command trigger</th>
@@ -66,7 +66,7 @@
         <div class="column four wide">
             {% set base_key = 'c3' %}
             <div class="commandlist-container {{ base_key }}">
-            <table class="ui table collapsed collapsing commandlist {{ base_key }}" data-key="{{ base_key }}">
+            <table class="ui basic table collapsed collapsing commandlist inverted {{ base_key }}" data-key="{{ base_key }}">
                 <thead>
                     <tr>
                         <th>Command trigger</th>

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -2,7 +2,7 @@
 {% set active_page = 'contact' %}
 {% block title %}Contact{% endblock %}
 {% block body %}
-<div class="ui segment">
+<div class="ui segment inverted" style="background: none;">
 <h2>Contact</h2>
 {% if maintainer is not none %}
 <p>Hi, I'm {{ maintainer.name }}! I'm the host and maintainer of {{ bot.name }}.</p>

--- a/templates/decks/all.html
+++ b/templates/decks/all.html
@@ -4,8 +4,8 @@
 {% block body %}
 <h2>Decks - Top 25</h2>
 {% include 'decks/menu.html' %}
-<div class="ui bottom attached tab segment active" data-tab="custom">
-    <table class="ui very basic table">
+<div class="ui bottom attached tab segment active" data-tab="custom" style="background: #2d2d2d;">
+    <table class="ui very basic table inverted">
         <thead>
             <tr>
                 <th>ID</th>

--- a/templates/decks/by_class.html
+++ b/templates/decks/by_class.html
@@ -4,8 +4,8 @@
 {% block body %}
 <h2>Decks - {{ deck_class }}</h2>
 {% include 'decks/menu.html' %}
-<div class="ui bottom attached tab segment active" data-tab="custom">
-    <table class="ui very basic table">
+<div class="ui bottom attached tab segment active" data-tab="custom" style="background: #2d2d2d;">
+    <table class="ui very basic table inverted">
         <thead>
             <tr>
                 <th>ID</th>

--- a/templates/helper/command_table.html
+++ b/templates/helper/command_table.html
@@ -1,4 +1,4 @@
-<table style="width: 340px" class="ui very basic collapsing celled table">
+<table style="width: 340px" class="ui very basic collapsing celled table inverted">
     <thead>
         <tr style="width: 50%">
             <th>Setting</th>

--- a/templates/helper/commands_page.html
+++ b/templates/helper/commands_page.html
@@ -3,9 +3,9 @@
         <div class="ui segment help">
             <p>Click a command to the left to see information about it.</p>
         </div>
-        <div class="ui segment supercool" style="display: none;">
+        <div class="ui segment supercool inverted" style="display: none; background: #2d2d2d">
             <h5>Command settings</h5>
-            <table class="ui table collapsed celled collapsing {{ base_key }} command-data">
+            <table class="ui very basic inverted table collapsed celled collapsing {{ base_key }} command-data">
                 <tbody>
                     <tr data-key="id">
                         <td class="label collapsing">ID</td>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -33,7 +33,7 @@
           <div class="ui transparent icon input">
               <form id="usersearch">
                   <div class="ui action input">
-                      <input type="text" name="username" class="username" placeholder="Username">
+                      <input type="text" name="username" class="username" placeholder="Username" style="background-color: #1b1c1d !important; color: white !important; border-color: rgba(255, 255, 255, 0.1) !important;">
                       <button class="ui icon button" style="opacity: 50%;">
                           <i class="search icon"></i>
                       </button>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -34,7 +34,7 @@
               <form id="usersearch">
                   <div class="ui action input">
                       <input type="text" name="username" class="username" placeholder="Username">
-                      <button class="ui icon button inverted">
+                      <button class="ui icon button" style="opacity: 50%;">
                           <i class="search icon"></i>
                       </button>
                   </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -20,7 +20,7 @@
 {% set active_page = active_page|default('home') %}
 <header class="main header">
 {% block menu %}
-    <div class="ui top fixed menu">
+    <div class="ui top fixed menu inverted">
         <div class="menu" style="margin:auto;">
         {% for menuitem in nav_bar_header %}
         <a class="item{% if menuitem.id == active_page %} active{% endif %}" href="{{ menuitem.href }}">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -49,7 +49,6 @@
     {% block body %}{% endblock %}
 </div>
 </main>
-<br />
 <footer class="main footer">
 <div class="ui inverted vertical footer segment">
     <div class="ui container">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -34,7 +34,7 @@
               <form id="usersearch">
                   <div class="ui action input">
                       <input type="text" name="username" class="username" placeholder="Username">
-                      <button class="ui icon button">
+                      <button class="ui icon button inverted">
                           <i class="search icon"></i>
                       </button>
                   </div>

--- a/templates/playsounds.html
+++ b/templates/playsounds.html
@@ -3,7 +3,7 @@
 {% block title %}Playsounds{% endblock %}
 {% block body %}
     <h2>Playsounds</h2>
-    <div class="ui icon message">
+    <div class="ui icon message inverted">
         <i class="info circle icon"></i>
         <div class="content">
             <div class="header">
@@ -41,7 +41,7 @@
         </div>
     </div>
 
-    <div class="ui icon {{ "positive" if playsounds_enabled else "negative" }} message">
+    <div class="ui icon {{ "positive" if playsounds_enabled else "negative" }} inverted message">
         <i class="{{ "check circle" if playsounds_enabled else "exclamation triangle" }} icon"></i>
         <div class="content">
             <div class="header">
@@ -58,7 +58,7 @@
     </div>
 
     <h3>List of available Playsounds</h3>
-    <table class="ui collapsing single line compact table">
+    <table class="ui collapsing single line compact very basic table inverted">
         <thead>
         <tr>
             <th>Name</th>

--- a/templates/playsounds.html
+++ b/templates/playsounds.html
@@ -74,7 +74,7 @@
                 <td>
                     <div class="ui action input compact">
                         <input type="text" readonly="readonly" class="copyInput compact"
-                               value="!#playsound {{ playsound.name }}" style="background-color: #2d2d2d !important; color: white !important; border-color: rgba(255,255,255,.1);">
+                               value="!#playsound {{ playsound.name }}">
                         <button type="button" name="copyToken" title="Copy command to clipboard"
                                 class="copyButton ui right icon button compact inverted">
                             <i class="clipboard icon"></i>

--- a/templates/playsounds.html
+++ b/templates/playsounds.html
@@ -76,7 +76,7 @@
                         <input type="text" readonly="readonly" class="copyInput compact"
                                value="!#playsound {{ playsound.name }}">
                         <button type="button" name="copyToken" title="Copy command to clipboard"
-                                class="copyButton ui right icon button compact">
+                                class="copyButton ui right icon button compact inverted">
                             <i class="clipboard icon"></i>
                         </button>
                     </div>
@@ -89,11 +89,11 @@
                          data-name="{{ playsound.name }}"
                          data-link="{{ playsound.link }}"
                          data-volume="{{ playsound.volume }}">
-                        <button class="positive play-in-browser-play ui labeled icon button compact">
+                        <button class="green inverted play-in-browser-play ui labeled icon button compact">
                             <i class="play circle outline icon"></i>
                             Test in browser
                         </button>
-                        <button class="play-in-browser-stop ui labeled button compact icon disabled">
+                        <button class="play-in-browser-stop ui labeled button compact icon disabled inverted">
                             <i class="stop circle outline icon"></i>Stop Playback
                         </button>
                     </div>

--- a/templates/playsounds.html
+++ b/templates/playsounds.html
@@ -74,7 +74,7 @@
                 <td>
                     <div class="ui action input compact">
                         <input type="text" readonly="readonly" class="copyInput compact"
-                               value="!#playsound {{ playsound.name }}">
+                               value="!#playsound {{ playsound.name }}" style="background-color: #2d2d2d !important; color: white !important; border-color: rgba(255,255,255,.1);">
                         <button type="button" name="copyToken" title="Copy command to clipboard"
                                 class="copyButton ui right icon button compact inverted">
                             <i class="clipboard icon"></i>

--- a/templates/points.html
+++ b/templates/points.html
@@ -35,13 +35,13 @@
         <div class="field username">
             <input type="text" placeholder="Username">
         </div>
-        <button class="ui submit button">Submit</button>
+        <button class="ui submit button inverted">Submit</button>
     </form>
     <div class="ui response hidden"></div>
 </div>
 <h2>Points Leaderboard</h2>
 <div id="top_users">
-    <table class="ui very basic table collapsing">
+    <table class="ui very basic table collapsing inverted">
         <thead>
             <tr>
                 <th>Rank</th>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -9,7 +9,7 @@
 <h3><a href="https://stats.streamelements.com/c/{{ streamer.full_name }}">StreamElements stats page</a></h3>
 <div id="stats">
     <h3>Top 5 Commands</h3>
-    <table class="ui very basic table">
+    <table class="ui very basic table inverted">
         <thead>
             <tr>
                 <th>Command</th>
@@ -26,7 +26,7 @@
     </table>
     {% if 'linefarming' in modules %}
         <h3>Top 5 Line Farmers</h3>
-        <table class="ui very basic table">
+        <table class="ui very basic table inverted">
             <thead>
                 <tr>
                     <th>Username</th>

--- a/templates/stats_duels.html
+++ b/templates/stats_duels.html
@@ -6,7 +6,7 @@
 <div id="stats">
     <div class="minitable stats">
         <h3>Top 5 Winrate</h3>
-        <table class="ui very basic table celled ">
+        <table class="ui very basic table celled inverted">
             <thead>
                 <tr>
                     <th>User</th>
@@ -25,7 +25,7 @@
     </div>
     <div class="minitable stats">
         <h3>Top 5 Duels Won</h3>
-        <table class="ui very basic table celled ">
+        <table class="ui very basic table celled inverted">
             <thead>
                 <tr>
                     <th>User</th>
@@ -44,7 +44,7 @@
     </div>
     <div class="minitable stats">
         <h3>Top 5 Duels Lost</h3>
-        <table class="ui very basic table celled ">
+        <table class="ui very basic table celled inverted">
             <thead>
                 <tr>
                     <th>User</th>
@@ -63,7 +63,7 @@
     </div>
     <div class="minitable stats">
         <h3>Top 5 Points Won</h3>
-        <table class="ui very basic table celled ">
+        <table class="ui very basic table celled inverted">
             <thead>
                 <tr>
                     <th>User</th>
@@ -82,7 +82,7 @@
     </div>
     <div class="minitable stats">
         <h3>Top 5 Points Lost</h3>
-        <table class="ui very basic table celled ">
+        <table class="ui very basic table celled inverted">
             <thead>
                 <tr>
                     <th>User</th>
@@ -101,7 +101,7 @@
     </div>
     <div class="minitable stats">
         <h3>Bottom 5 Winrate</h3>
-        <table class="ui very basic table celled ">
+        <table class="ui very basic table celled inverted">
             <thead>
                 <tr>
                     <th>User</th>


### PR DESCRIPTION
Replaced the blinding default light mode with a custom dark mode. Working example: https://bot.alazymeme.com/

Fixes https://github.com/pajbot/pajbot/issues/653

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [ ] Documentation in docs/ or install-docs/ was updated, if applicable