### PR TITLE
Remove prose-wrapping in all .md files

### DIFF
--- a/.prettierrc.toml
+++ b/.prettierrc.toml
@@ -9,3 +9,8 @@ tabWidth = 4
 files = ["*.js"]
 [overrides.options]
 singleQuote = true
+
+[[overrides]]
+files = ["*.md"]
+[overrides.options]
+proseWrap = "never"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,66 +184,41 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Breaking: pajbot now uses PostgreSQL instead of MySQL as its supported
-  database engine. It is not possible to continue to use MySQL.  
+- Breaking: pajbot now uses PostgreSQL instead of MySQL as its supported database engine. It is not possible to continue to use MySQL.  
   To migrate your existing database(s):
 
   - Install new requirements from apt: `sudo apt-get install libpq-dev`
   - Bring your installed dependencies up-to-date with `./scripts/venvinstall.sh`
   - Install and start PostgreSQL, if you have not done so already
-  - Create the pajbot PostgreSQL user, a database and optionally a schema for
-    the bot to use. (see the updated SQL section of
-    [the install docs](./install-docs/debian10/install-debian10.txt))
-  - Edit `./scripts/migrate-mysql-to-postgresql.py` with a connection string for
-    the old MySQL database, and your new PostgreSQL database.
-  - Stop pajbot:
-    `sudo systemctl stop pajbot@streamername pajbot-web@streamername`
-  - Backup your data:
-    `sudo mysqldump --single-transaction --result-file=mysql-dump-streamername.sql pajbot_streamername`
+  - Create the pajbot PostgreSQL user, a database and optionally a schema for the bot to use. (see the updated SQL section of [the install docs](./install-docs/debian10/install-debian10.txt))
+  - Edit `./scripts/migrate-mysql-to-postgresql.py` with a connection string for the old MySQL database, and your new PostgreSQL database.
+  - Stop pajbot: `sudo systemctl stop pajbot@streamername pajbot-web@streamername`
+  - Backup your data: `sudo mysqldump --single-transaction --result-file=mysql-dump-streamername.sql pajbot_streamername`
   - Activate the python virtualenv: `source venv/bin/activate`
   - Run `./scripts/migrate-mysql-to-postgresql` to move the data
-  - Update the `sql` connection string in your bot config (see the updated
-    [example config](./configs/example.ini) for
-    examples)
-  - Start pajbot again:
-    `sudo systemctl start pajbot@streamername pajbot-web@streamername`
-  - Drop the old MySQL database:
-    `sudo mysql -e "DROP DATABASE pajbot_streamername"`
+  - Update the `sql` connection string in your bot config (see the updated [example config](./configs/example.ini) for examples)
+  - Start pajbot again: `sudo systemctl start pajbot@streamername pajbot-web@streamername`
+  - Drop the old MySQL database: `sudo mysql -e "DROP DATABASE pajbot_streamername"`
 
-  The procedure for new bot installations is described in the
-  [install documentation](./install-docs).
+  The procedure for new bot installations is described in the [install documentation](./install-docs).
 
-- Breaking: If you were using the
-  [chatters microservice](https://github.com/pajbot/chatters), you must update
-  it to be able to use it after the PostgreSQL update.
-- Breaking (if you rely on it in an automatic way somehow): `venvinstall.sh` has
-  been moved from `./install` into `./scripts`, where all other shell scripts
-  also reside.
-- Major: Official support for python 3.5 has been removed. Only python 3.6 or
-  above will be supported from this release on.
-- Feature: Added `!namechange <oldusername> <newusername>` command for migrating
-  users that changed their twitch name. (Level 2000 only).
-  `./scripts/transfer-{all,sql,redis}` scripts have been removed.
+- Breaking: If you were using the [chatters microservice](https://github.com/pajbot/chatters), you must update it to be able to use it after the PostgreSQL update.
+- Breaking (if you rely on it in an automatic way somehow): `venvinstall.sh` has been moved from `./install` into `./scripts`, where all other shell scripts also reside.
+- Major: Official support for python 3.5 has been removed. Only python 3.6 or above will be supported from this release on.
+- Feature: Added `!namechange <oldusername> <newusername>` command for migrating users that changed their twitch name. (Level 2000 only). `./scripts/transfer-{all,sql,redis}` scripts have been removed.
 - Minor: Removed `!reload` command since it did nothing.
 - Minor: Modules can now be configured to only allow users above a certain level to configure them. #108
 - Minor: Removed "Personal Uptime" module.
-- Bugfix: A series of bugs (including the `!laststream` command sometimes not
-  working) caused by a mismatch of datetime-aware and datetime-naive objects.
-- Bugfix: If redis is busy loading data, the bot no longer exists, and waits for
-  completion instead.
+- Bugfix: A series of bugs (including the `!laststream` command sometimes not working) caused by a mismatch of datetime-aware and datetime-naive objects.
+- Bugfix: If redis is busy loading data, the bot no longer exists, and waits for completion instead.
 - Bugfix: `/api/v1/user/:username` no longer fetches `nl_rank` from redis twice.
-- Bugfix: If no git data is available, web interface will no longer show
-  `Last commit:`, instead last commit will be omitted altogether
-- Bugfix: Fixed a series of bugs (including the `!laststream` command sometimes
-  not working) caused by a mismatch of datetime-aware and datetime-naive
-  objects.
-- Bugfix: Commands are now only checked against banphrases, ascii and massping
-  checks if you enabled `run_through_banphrases` (e.g. via `--checkmsg`) (#478)
+- Bugfix: If no git data is available, web interface will no longer show `Last commit:`, instead last commit will be omitted altogether
+- Bugfix: Fixed a series of bugs (including the `!laststream` command sometimes not working) caused by a mismatch of datetime-aware and datetime-naive objects.
+- Bugfix: Commands are now only checked against banphrases, ascii and massping checks if you enabled `run_through_banphrases` (e.g. via `--checkmsg`) (#478)
 - Bugfix: Subscribers refresh now correctly sets the `active_subs` KVI value.
 - Bugfix: You can no longer ignore yourself
 - Bugfix: You can now use the same phrases (1k, "all", etc.) with the `!givepoints` command.
-- Documentation Bugfix: `$(urlfetch)` returns the response body, not request
-  body
+- Documentation Bugfix: `$(urlfetch)` returns the response body, not request body
 
 <!--
 - Internal: New (stupider) migrations system that directly uses SQL, and can additionally
@@ -261,32 +236,17 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 
 ## v1.36
 
-- Breaking: In your `config.ini`, rename `[webtwitchapi]` to `[twitchapi]` and
-  delete the old `[twitchapi]` config file entry. See
-  [the example config](https://github.com/pajbot/pajbot/blob/677651d416fa60c80ef939df8666bf554237ae0d/install-docs/debian10/kkonatestbroadcaster.ini#L62)
-  for example values.
-- Breaking: a `redirect_uri` is now always required under `[twitchapi]` in your
-  `config.ini`.
-- Breaking: If you want to continue fetching subscribers, you will need to have
-  the streamer log in once with `/streamer_login`. Then the bot will
-  automatically start fetching a list of subscribers regularly.
-- Major: To be able to use game and title updates with `!settitle` and
-  `!setgame`, re-authenticate the bot with `/bot_login`. Then ask the streamer
-  to add the bot as a channel editor.
-- Major: Dependency on `twitch-api-v3-proxy` has been removed. You can uninstall
-  that service if you were running it. (The bot now uses the new Twitch v5 and
-  Helix APIs)
+- Breaking: In your `config.ini`, rename `[webtwitchapi]` to `[twitchapi]` and delete the old `[twitchapi]` config file entry. See [the example config](https://github.com/pajbot/pajbot/blob/677651d416fa60c80ef939df8666bf554237ae0d/install-docs/debian10/kkonatestbroadcaster.ini#L62) for example values.
+- Breaking: a `redirect_uri` is now always required under `[twitchapi]` in your `config.ini`.
+- Breaking: If you want to continue fetching subscribers, you will need to have the streamer log in once with `/streamer_login`. Then the bot will automatically start fetching a list of subscribers regularly.
+- Major: To be able to use game and title updates with `!settitle` and `!setgame`, re-authenticate the bot with `/bot_login`. Then ask the streamer to add the bot as a channel editor.
+- Major: Dependency on `twitch-api-v3-proxy` has been removed. You can uninstall that service if you were running it. (The bot now uses the new Twitch v5 and Helix APIs)
 - Feature: Dubtrack module can now show requester
-- Feature: Dubtrack module can automatically post a message when a new song
-  starts playing
-- Bugfix: Fix a recurring error that could appear when fetching the stream
-  live/offline status.
-- Bugfix: Make subscriber fetch routine more accurate (will now fetch the
-  correct/accurate number of subscribers)
-- Bugfix: `!settitle` and `!setgame` are now packaged as a module, you no longer
-  need to add these commands as `funccommand`s.
-- Bugfix: Updated link checker module to use the latest version of the safe
-  browsing API.
+- Feature: Dubtrack module can automatically post a message when a new song starts playing
+- Bugfix: Fix a recurring error that could appear when fetching the stream live/offline status.
+- Bugfix: Make subscriber fetch routine more accurate (will now fetch the correct/accurate number of subscribers)
+- Bugfix: `!settitle` and `!setgame` are now packaged as a module, you no longer need to add these commands as `funccommand`s.
+- Bugfix: Updated link checker module to use the latest version of the safe browsing API.
 
 ## Older versions
 
@@ -322,8 +282,7 @@ Changelogs were kept sporadically before this point
 - /api/v1/user/<username> now returns points_rank instead of rank for the points rank.
 - Refactored all the API code to be better structured
 - Reorganized how the web app is started, cleaning up app.py a lot
-- The HSbet reminders now print stats about how many points are bet on win and how many points are
-  bet on lose.
+- The HSbet reminders now print stats about how many points are bet on win and how many points are bet on lose.
 - Added navigation links on the /pleblist/history page
 
 ### Added

--- a/install-docs/README.md
+++ b/install-docs/README.md
@@ -4,8 +4,7 @@ Welcome to the installation instructions for pajbot!
 
 Below is the index for a full list of installation instructions for pajbot.
 
-These installation instructions will install pajbot in a way that allows you to run pajbot for multiple streamers at once without too much duplication.
-For this reason, these installation instructions are split into two big parts: Installation of pajbot, and creating a pajbot instance for a single channel (which you can repeat as needed, should you want to run pajbot in multiple channels, for different streamers for example).
+These installation instructions will install pajbot in a way that allows you to run pajbot for multiple streamers at once without too much duplication. For this reason, these installation instructions are split into two big parts: Installation of pajbot, and creating a pajbot instance for a single channel (which you can repeat as needed, should you want to run pajbot in multiple channels, for different streamers for example).
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -52,8 +51,7 @@ sudo apt install libssl-dev libpq-dev build-essential
 
 ## Set up a system user
 
-For security reasons, you shouldn't run pajbot as the `root` user on your server.
-You can create a low-privilege "system" user for pajbot like this:
+For security reasons, you shouldn't run pajbot as the `root` user on your server. You can create a low-privilege "system" user for pajbot like this:
 
 ```bash
 sudo adduser --system --group pajbot --home /opt/pajbot
@@ -102,8 +100,7 @@ sudo -u postgres createdb --owner=pajbot pajbot
 
 ## Install Redis
 
-Pajbot also needs an instance of [Redis](https://redis.io/) to run.
-The redis database server does not need any manual setup - all you have to do is install redis:
+Pajbot also needs an instance of [Redis](https://redis.io/) to run. The redis database server does not need any manual setup - all you have to do is install redis:
 
 ```bash
 sudo apt install redis-server
@@ -129,8 +126,7 @@ sudo apt install nginx
 
 We will configure nginx later.
 
-> Note: You can find a basic nginx configuration setup including HTTP -> HTTPS redirect, recommended SSL configuration parameters, etc. [over here](./full-nginx-setup/README.md).
-> If you don't already have a basic nginx setup, we strongly recommend you follow the linked guideline now.
+> Note: You can find a basic nginx configuration setup including HTTP -> HTTPS redirect, recommended SSL configuration parameters, etc. [over here](./full-nginx-setup/README.md). If you don't already have a basic nginx setup, we strongly recommend you follow the linked guideline now.
 
 ## Install system services
 

--- a/install-docs/certbot-with-cloudflare/README.md
+++ b/install-docs/certbot-with-cloudflare/README.md
@@ -97,5 +97,4 @@ ssl_certificate /etc/letsencrypt/live/your-domain.com/fullchain.pem;
 ssl_certificate_key /etc/letsencrypt/live/your-domain.com/privkey.pem;
 ```
 
-> Note! If you have requested a wildcard certificate (as we have done here in the example), you can re-use the same certificate for multiple bots.
-> E.g. if you have bots running under the two subdomains `streamer_a.your-domain.com` and `streamer_b.your-domain.com`, and you have a wildcard certificate for `*.your-domain.com`, then both these site configurations can share the same certificate (`/etc/letsencrypt/live/your-domain.com/fullchain.pem` for example).
+> Note! If you have requested a wildcard certificate (as we have done here in the example), you can re-use the same certificate for multiple bots. E.g. if you have bots running under the two subdomains `streamer_a.your-domain.com` and `streamer_b.your-domain.com`, and you have a wildcard certificate for `*.your-domain.com`, then both these site configurations can share the same certificate (`/etc/letsencrypt/live/your-domain.com/fullchain.pem` for example).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,8 +19,7 @@ redis-cli --pipe < redis_dump_streamer.bin
 Generates a list of all unicode emoji.
 
 Useful to generate/refresh the `emoji.py` file with fresh data.  
-Draws directly from the official unicode `emoji-test.txt` file and generates a
-list format that can be inserted into `../pajbot/emoji.py`.
+Draws directly from the official unicode `emoji-test.txt` file and generates a list format that can be inserted into `../pajbot/emoji.py`.
 
 E.g.:
 


### PR DESCRIPTION
Since it was decided not to have prose-wrapping style, I thought it would be useful to (a) enforce this style, and (b) revert previous times when this format was applied.

I should mention, all the changes to the .md files was done by prettier, not manually.
If we want to enforce this style, we have to change the existing files so the CI passes (and so they aren't updated on future uses of the reformat script), obviously.


Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
