### PR TITLE
Reconnect on connection error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Bugfix: Fixed incorrect redirect after completing the `/bot_login` or `/streamer_login` process. (#869)
+- Bugfix: Fixed reconnection logic, we previously didn't handle errors like "connection refused" or "connection timed out". (#872)
 
 ## v1.44
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unversioned
 
 - Bugfix: Fixed incorrect redirect after completing the `/bot_login` or `/streamer_login` process. (#869)
-- Bugfix: Fixed reconnection logic, we previously didn't handle errors like "connection refused" or "connection timed out". (#872)
+- Bugfix: Added retry logic for when opening connection fails. (#872)
 
 ## v1.44
 

--- a/pajbot/managers/connection.py
+++ b/pajbot/managers/connection.py
@@ -91,7 +91,7 @@ class ConnectionManager:
 
             return True
         except:
-            log.exception("Connection failed, retrying")
+            log.exception("Failed to open connection, retrying")
             self.bot.execute_delayed(2, lambda: self.start())
             return False
 

--- a/pajbot/managers/connection.py
+++ b/pajbot/managers/connection.py
@@ -92,7 +92,7 @@ class ConnectionManager:
             return True
         except:
             log.exception("Connection failed, retrying")
-            self.bot.execute_delayed(1, lambda: self.start())
+            self.bot.execute_delayed(2, lambda: self.start())
             return False
 
     def make_new_connection(self):

--- a/pajbot/managers/connection.py
+++ b/pajbot/managers/connection.py
@@ -91,24 +91,22 @@ class ConnectionManager:
 
             return True
         except:
-            log.exception("babyrage")
+            log.exception("Connection failed, retrying")
+            self.bot.execute_delayed(1, lambda: self.start())
             return False
 
     def make_new_connection(self):
         ip = self.host
         port = self.port
 
-        try:
-            ssl_factory = Factory(wrapper=ssl.wrap_socket)
-            self.main_conn = Connection(self.reactor)
-            with self.reactor.mutex:
-                self.reactor.connections.append(self.main_conn)
-            self.main_conn.connect(
-                ip, port, self.bot.nickname, self.bot.password, self.bot.nickname, connect_factory=ssl_factory
-            )
-            self.main_conn.cap("REQ", "twitch.tv/commands", "twitch.tv/tags")
-        except irc.client.ServerConnectionError:
-            return False
+        ssl_factory = Factory(wrapper=ssl.wrap_socket)
+        self.main_conn = Connection(self.reactor)
+        with self.reactor.mutex:
+            self.reactor.connections.append(self.main_conn)
+        self.main_conn.connect(
+            ip, port, self.bot.nickname, self.bot.password, self.bot.nickname, connect_factory=ssl_factory
+        )
+        self.main_conn.cap("REQ", "twitch.tv/commands", "twitch.tv/tags")
 
     def on_disconnect(self, _chatconn):
         log.error("Disconnected from IRC")


### PR DESCRIPTION
Previously if a connection error handled during the actual "connection phase" (e.g. connection timed out, connection refused), we ignored it and never tried to connect again.

This attempts to remedy that, although it's not something I have set up a test case for but it worked for Leppunen once babyrage

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
