### PR TITLE
Add level requirements to certain modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
+- Minor: Changed level requirements for moderation and some admincommands modules
 - Minor: Added option to unban user from chat when the `!unpermaban` command is used (#739, #887)
 - Minor: Added whisper timeout reasons to the emote limit module (#866)
 - Minor: Added `timeout_end` field to User API Response and `!debug user` command output. (#875)

--- a/pajbot/modules/ascii.py
+++ b/pajbot/modules/ascii.py
@@ -15,6 +15,7 @@ class AsciiProtectionModule(BaseModule):
     NAME = "ASCII Protection"
     DESCRIPTION = "Times out users who post messages that contain too many ASCII characters."
     CATEGORY = "Moderation"
+    CONFIGURE_LEVEL = 1000
     SETTINGS = [
         ModuleSetting(
             key="min_msg_length",

--- a/pajbot/modules/banphrase.py
+++ b/pajbot/modules/banphrase.py
@@ -17,6 +17,7 @@ class BanphraseModule(BaseModule):
     DESCRIPTION = "Looks at each message for banned phrases, and takes actions accordingly"
     ENABLED_DEFAULT = True
     CATEGORY = "Moderation"
+    CONFIGURE_LEVEL = 1000
     SETTINGS = []
 
     def is_message_bad(self, source, msg_raw, _event):

--- a/pajbot/modules/basic/permaban.py
+++ b/pajbot/modules/basic/permaban.py
@@ -19,6 +19,7 @@ class PermabanModule(BaseModule):
     NAME = "Permaban"
     DESCRIPTION = "Permabans a user (re-bans them if unbanned by a mod)"
     CATEGORY = "Moderation"
+    CONFIGURE_LEVEL = 1500
     ENABLED_DEFAULT = True
     MODULE_TYPE = ModuleType.TYPE_ALWAYS_ENABLED
     PARENT_MODULE = BasicCommandsModule

--- a/pajbot/modules/basic/stream_update.py
+++ b/pajbot/modules/basic/stream_update.py
@@ -17,6 +17,7 @@ class StreamUpdateModule(BaseModule):
     NAME = "Stream Update Commands"
     DESCRIPTION = "Update the stream game and title using commands from chat"
     CATEGORY = "Feature"
+    CONFIGURE_LEVEL = 1000
     ENABLED_DEFAULT = True
     PARENT_MODULE = BasicCommandsModule
     SETTINGS = [

--- a/pajbot/modules/casechecker.py
+++ b/pajbot/modules/casechecker.py
@@ -12,6 +12,7 @@ class CaseCheckerModule(BaseModule):
     NAME = "Case Checker"
     DESCRIPTION = "Times out users who post messages that contain lowercase/uppercase letters."
     CATEGORY = "Moderation"
+    CONFIGURE_LEVEL = 1000
     SETTINGS = [
         ModuleSetting(
             key="timeout_uppercase",

--- a/pajbot/modules/emote_limit.py
+++ b/pajbot/modules/emote_limit.py
@@ -12,6 +12,7 @@ class EmoteLimitModule(BaseModule):
     NAME = "Emote Limit"
     DESCRIPTION = "Times out users who post too many emotes"
     CATEGORY = "Moderation"
+    CONFIGURE_LEVEL = 1000
     SETTINGS = [
         ModuleSetting(
             key="max_emotes",

--- a/pajbot/modules/emote_timeout.py
+++ b/pajbot/modules/emote_timeout.py
@@ -13,6 +13,7 @@ class EmoteTimeoutModule(BaseModule):
     NAME = "Emote Timeout"
     DESCRIPTION = "Times out users who post emoji or Twitch, BTTV or FFZ emotes"
     CATEGORY = "Moderation"
+    CONFIGURE_LEVEL = 1000
     SETTINGS = [
         ModuleSetting(
             key="timeout_twitch", label="Timeout any Twitch emotes", type="boolean", required=True, default=False

--- a/pajbot/modules/linkchecker.py
+++ b/pajbot/modules/linkchecker.py
@@ -151,6 +151,7 @@ class LinkCheckerModule(BaseModule):
     DESCRIPTION = "Checks links if they're bad"
     ENABLED_DEFAULT = True
     CATEGORY = "Moderation"
+    CONFIGURE_LEVEL = 1000
     SETTINGS = [
         ModuleSetting(
             key="ban_pleb_links",

--- a/pajbot/modules/massping.py
+++ b/pajbot/modules/massping.py
@@ -22,6 +22,7 @@ class MassPingProtectionModule(BaseModule):
     NAME = "Mass Ping Protection"
     DESCRIPTION = "Times out users who post messages that mention too many users at once."
     CATEGORY = "Moderation"
+    CONFIGURE_LEVEL = 1000
     SETTINGS = [
         ModuleSetting(
             key="max_ping_count",

--- a/pajbot/modules/maxmsglength.py
+++ b/pajbot/modules/maxmsglength.py
@@ -15,6 +15,7 @@ class MaxMsgLengthModule(BaseModule):
     NAME = "Maximum Message Length"
     DESCRIPTION = "Times out users who post messages that contain too many characters."
     CATEGORY = "Moderation"
+    CONFIGURE_LEVEL = 1000
     SETTINGS = [
         ModuleSetting(
             key="max_msg_length",

--- a/pajbot/modules/pnsl.py
+++ b/pajbot/modules/pnsl.py
@@ -15,6 +15,7 @@ class PNSLModule(BaseModule):
     NAME = "Run P&SL lists"
     DESCRIPTION = "Run P&SL lists through the !runpnsl command"
     CATEGORY = "Moderation"
+    CONFIGURE_LEVEL = 1500
     SETTINGS = [
         ModuleSetting(
             key="level",

--- a/pajbot/modules/repspam.py
+++ b/pajbot/modules/repspam.py
@@ -15,6 +15,7 @@ class RepspamModule(BaseModule):
     DESCRIPTION = "Times out messages containing repetitive spam"
     ENABLED_DEFAULT = False
     CATEGORY = "Moderation"
+    CONFIGURE_LEVEL = 1000
     SETTINGS = [
         ModuleSetting(
             key="bypass_level",

--- a/pajbot/modules/warning.py
+++ b/pajbot/modules/warning.py
@@ -8,6 +8,7 @@ class WarningModule(BaseModule):
     NAME = "Warnings"
     DESCRIPTION = "Gives people warnings before timing them out for the full duration for banphrase and stuff"
     CATEGORY = "Moderation"
+    CONFIGURE_LEVEL = 1000
     ENABLED_DEFAULT = True
     SETTINGS = [
         ModuleSetting(


### PR DESCRIPTION
Added level 1000 requirements to most moderation modules, upped some more critical ones to 1500.

Fixes https://github.com/pajbot/pajbot/issues/492

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [ ] Documentation in docs/ or install-docs/ was updated, if applicable