### PR TITLE
Fix retry logic if getting the login token fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Minor: Added a live alerts module to notify chat when the streamer goes live (#924)
 - Minor: Added a `streamer_display` variable to show the capitalized version of the broadcaster (#924)
 - Minor: Removed the dubtrack module (#916)
+- Minor: It is no longer necessary to restart the bot during installation process after completing the `/bot_login` process. (#929)
+- Bugfix: Bot now properly attempts to reconnect if getting the login token failed (e.g. no token or refresh failed). (#929)
 
 ## v1.45
 

--- a/install-docs/README.md
+++ b/install-docs/README.md
@@ -227,11 +227,7 @@ sudo systemctl enable --now pajbot@streamer_name pajbot-web@streamer_name
 
 One last step: You need to give your pajbot instance access to use your bot account! For this purpose, visit the URL `https://streamer_name.your-domain.com/bot_login` and complete the login procedure to authorize the bot.
 
-Then, to finally make the bot come online in chat, run:
-
-```bash
-sudo systemctl restart pajbot@streamer_name
-```
+The bot will then automatically come online in chat within about 2-3 seconds of you completing the login process.
 
 ## Further steps
 

--- a/pajbot/managers/irc.py
+++ b/pajbot/managers/irc.py
@@ -74,6 +74,13 @@ class IRCManager:
             self._make_new_connection()
         except:
             log.exception("Failed to open connection, retrying in 2 seconds")
+
+            # reset our state back to if we weren't connected at all, so we can start fresh once start() is called again
+            # e.g. if _make_new_connection() fails at the part where it gets the login password, and if this wasn't here,
+            # then it would leave a self.conn behind that isn't None. (and the AssertionError above would be raised
+            # in 2 seconds, once self.start() gets called again via execute_delayed)
+            self.conn = None
+
             self.bot.execute_delayed(2, lambda: self.start())
 
     def _make_new_connection(self):


### PR DESCRIPTION
I tested that it works. It just spams the NoTokenError every 2 seconds until you complete the bot_login process.

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
