### PR TITLE
Add a second optional live message when going live (live alerts module)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: Added a secondary optional message to send when the channel goes live (live alerts module) (#938)
 - Minor: Added a new module to print a chat alert when a user announces they are new (#926)
 - Minor: Added a live alerts module to notify chat when the streamer goes live (#924)
 - Minor: Added a `streamer_display` variable to show the capitalized version of the broadcaster (#924)

--- a/pajbot/modules/chat_alerts/livealert.py
+++ b/pajbot/modules/chat_alerts/livealert.py
@@ -33,7 +33,7 @@ class LiveAlertModule(BaseModule):
             placeholder="@{streamer} TWEET THAT YOU'RE LIVE OMGScoots",
             default="",
             constraints={"max_str_len": 400},
-        )
+        ),
     ]
 
     def __init__(self, bot):
@@ -44,13 +44,7 @@ class LiveAlertModule(BaseModule):
         streamer = self.bot.streamer_display
         game = self.bot.stream_manager.game
         title = self.bot.stream_manager.title
-        self.bot.say(
-            live_chat_message.format(
-                streamer=streamer,
-                game=game,
-                title=title,
-            )
-        )
+        self.bot.say(live_chat_message.format(streamer=streamer, game=game, title=title))
         if self.settings["extra_message"] != "":
             self.bot.say(self.settings["extra_message"].format(streamer=streamer))
 

--- a/pajbot/modules/chat_alerts/livealert.py
+++ b/pajbot/modules/chat_alerts/livealert.py
@@ -24,6 +24,15 @@ class LiveAlertModule(BaseModule):
             placeholder="{streamer} is now live! PogChamp Streaming {game}: {title}",
             default="{streamer} is now live! PogChamp Streaming {game}: {title}",
             constraints={"max_str_len": 400},
+        ),
+        ModuleSetting(
+            key="extra_message",
+            label="Extra message to post after the initial live message is posted. Leave empty to disable | Available arguments: {streamer}",
+            type="text",
+            required=False,
+            placeholder="@{streamer} TWEET THAT YOU'RE LIVE OMGScoots",
+            default="",
+            constraints={"max_str_len": 400},
         )
     ]
 
@@ -32,13 +41,18 @@ class LiveAlertModule(BaseModule):
 
     def on_stream_start(self, **rest):
         live_chat_message = self.settings["live_message"]
+        streamer = self.bot.streamer_display
+        game = self.bot.stream_manager.game
+        title = self.bot.stream_manager.title
         self.bot.say(
             live_chat_message.format(
-                streamer=self.bot.streamer_display,
-                game=self.bot.stream_manager.game,
-                title=self.bot.stream_manager.title,
+                streamer=streamer,
+                game=game,
+                title=title,
             )
         )
+        if self.settings["extra_message"] != "":
+            self.bot.say(self.settings["extra_message"].format(streamer=streamer))
 
     def enable(self, bot):
         HandlerManager.add_handler("on_stream_start", self.on_stream_start)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

Added a secondary optional message to post when the channel goes live (live alerts module)
