### PR TITLE
Add confirmation/failure message to tweet funccommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unversioned
 
+- Minor: The bot will now whisper you if your `!tweet` from the bot fails/is successful. (#942)
 - Minor: Added a secondary optional message to send when the channel goes live (live alerts module) (#938)
 - Minor: Added a new module to print a chat alert when a user announces they are new (#926)
 - Minor: Added a live alerts module to notify chat when the streamer goes live (#924)

--- a/pajbot/dispatch.py
+++ b/pajbot/dispatch.py
@@ -365,8 +365,10 @@ class Dispatch:
             try:
                 log.info("sending tweet: %s", message[:140])
                 bot.twitter_manager.twitter_client.update_status(status=message)
+                bot.whisper(source, "Tweet sent successfully!")
             except Exception:
                 log.exception("Caught an exception")
+                bot.whisper(source, "An error occurred while trying to send your tweet.")
 
     @staticmethod
     def eval(bot, source, message, event, args):


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

You will now get a whisper if your tweet fails to send or if your tweet sends successfully:
![image](https://user-images.githubusercontent.com/12804673/88178930-733bf700-cc6e-11ea-8988-b80baf18f7ed.png)

Fixes https://github.com/pajbot/pajbot/issues/927