### PR TITLE
Fix subscribers endpoint missing cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Bugfix: Cooldown and level values are now used correctly in the emotes module. (#947)
 - Bugfix: Bot now properly attempts to reconnect if getting the login token failed (e.g. no token or refresh failed). (#929)
 - Bugfix: Validate playsound names during creation (#502, #934)
+- Bugfix: Cleanly handle new response from Helix Subscriptions endpoint (#961, #962)
 
 ## v1.45
 

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -63,7 +63,7 @@ class TwitchHelixAPI(BaseTwitchAPI):
             responses.extend(response)
 
             # all pages iterated, done
-            if len(response) <= 0:
+            if len(response) <= 0 or pagination_cursor is None:
                 break
 
         return responses
@@ -168,6 +168,7 @@ class TwitchHelixAPI(BaseTwitchAPI):
             authorization=authorization,
         )
 
+        # Response with data
         # response =
         # {
         #   "data": [
@@ -186,9 +187,16 @@ class TwitchHelixAPI(BaseTwitchAPI):
         #     "cursor": "xxxx"
         #   }
         # }
+        #
+        # Response at end
+        # response =
+        # {
+        #   "data": [],
+        #   "pagination": {},
+        # }
 
         subscribers = [entry["user_id"] for entry in response["data"]]
-        pagination_cursor = response["pagination"]["cursor"]
+        pagination_cursor = response["pagination"].get("cursor", None)
 
         return subscribers, pagination_cursor
 

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -202,7 +202,12 @@ class TwitchHelixAPI(BaseTwitchAPI):
 
     def fetch_all_subscribers(self, broadcaster_id, authorization):
         """Fetch a list of all subscribers (user IDs) of a broadcaster."""
-        return self._fetch_all_pages(self._fetch_subscribers_page, broadcaster_id, authorization)
+        subscriber_ids = self._fetch_all_pages(self._fetch_subscribers_page, broadcaster_id, authorization)
+
+        # Dedupe the list of subscribers since the API can return the same IDs multiple times
+        subscriber_ids = list(set(subscriber_ids))
+
+        return subscriber_ids
 
     def _bulk_fetch_user_data(self, key_type, lookup_keys):
         all_entries = []


### PR DESCRIPTION
The Subscriptions endpoint now returns a valid cursor at the end of the
results, and as a result when we query that page we get an empty list of users.
However, the pagination object here does not contain a cursor, so we
check for that as another "exit strategy" now.

Data we got from the last cursor:
```
{
  "data": [],
  "pagination": {},
}
```

we handle this in the Helix apiwrapper by returning the pagination_cursor as None when the pagination should stop

Bonus meme: apparently we get duplicate user IDs now (idk if this happened before), so we deduplicate them in the module

Fixes #961 


Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
