### PR TITLE
Disallow the pnslrun command from being used while the streamer is live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Minor: Enforce an offline requirement for use of the `!pnslrun/!runpnsl` command
+- Minor: Enforce an offline requirement for use of the `!pnslrun/!runpnsl` command (#978)
 - Minor: Added VIP/Founder support. VIPs & Founders will now show in the !debug command, on the userpage on the website and on the API. The broadcaster badge will now also show on the user's webpage. If you experience any issues with the badges not showing on the webpage, typing `sudo rm -rf static/.webassets-cache/ static/gen && sudo systemctl restart pajbot-web@*` in the root folder of your pajbot installation will clear the webapp cache and restart your webapp. (#886)
 - Minor: Added a clip command module which allows users to clip the last 30 seconds of the stream. In order for this to function, the bot will need to be re-authed via the `/bot_login` process. (#950)
 - Minor: Improved `!remindme` command - the bot will alert you of the correct syntax (if incorrect) (#953)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Minor: Enforce an offline requirement for use of the `!pnslrun/!runpnsl` command (#978)
+- Minor: Added setting to disable the `!pnslrun`/`!runpnsl` command while stream is live (#978)
 - Minor: Added VIP/Founder support. VIPs & Founders will now show in the !debug command, on the userpage on the website and on the API. The broadcaster badge will now also show on the user's webpage. If you experience any issues with the badges not showing on the webpage, typing `sudo rm -rf static/.webassets-cache/ static/gen && sudo systemctl restart pajbot-web@*` in the root folder of your pajbot installation will clear the webapp cache and restart your webapp. (#886)
 - Minor: Added a clip command module which allows users to clip the last 30 seconds of the stream. In order for this to function, the bot will need to be re-authed via the `/bot_login` process. (#950)
 - Minor: Improved `!remindme` command - the bot will alert you of the correct syntax (if incorrect) (#953)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
+- Minor: Enforce an offline requirement for use of the `!pnslrun/!runpnsl` command
 - Minor: Added VIP/Founder support. VIPs & Founders will now show in the !debug command, on the userpage on the website and on the API. The broadcaster badge will now also show on the user's webpage. If you experience any issues with the badges not showing on the webpage, typing `sudo rm -rf static/.webassets-cache/ static/gen && sudo systemctl restart pajbot-web@*` in the root folder of your pajbot installation will clear the webapp cache and restart your webapp. (#886)
 - Minor: Added a clip command module which allows users to clip the last 30 seconds of the stream. In order for this to function, the bot will need to be re-authed via the `/bot_login` process. (#950)
 - Minor: Improved `!remindme` command - the bot will alert you of the correct syntax (if incorrect) (#953)

--- a/pajbot/modules/pnsl.py
+++ b/pajbot/modules/pnsl.py
@@ -62,10 +62,9 @@ class PNSLModule(BaseModule):
                 self.pnsl_token = bot.config["pnsl"].get("token", None)
 
     def run_pnsl(self, bot, source, message, event, args):
-        if self.settings["offline_only"] is True:
-            if not self.bot.is_online:
-                bot.whisper(source, f"{bot.streamer} is online! Skipping PNSL list eval.")
-                return False
+        if self.settings["offline_only"] and self.bot.is_online:
+            bot.whisper(source, f"{bot.streamer_display} is live! Skipping PNSL list eval.")
+            return False
 
         base_url = "https://bot.tetyys.com/api/v1/BotLists"
 

--- a/pajbot/modules/pnsl.py
+++ b/pajbot/modules/pnsl.py
@@ -17,13 +17,6 @@ class PNSLModule(BaseModule):
     CATEGORY = "Moderation"
     SETTINGS = [
         ModuleSetting(
-            key="offline_only",
-            label="Only allow the PNSL commands to be run while the stream is offline",
-            type="boolean",
-            required=True,
-            default=False,
-        ),
-        ModuleSetting(
             key="level",
             label="Level required to use the command",
             type="number",
@@ -49,6 +42,13 @@ class PNSLModule(BaseModule):
             placeholder="",
             default=30,
             constraints={"min_value": 5, "max_value": 60},
+        ),
+        ModuleSetting(
+            key="offline_only",
+            label="Only allow the PNSL commands to be run while the stream is offline",
+            type="boolean",
+            required=True,
+            default=False,
         ),
     ]
 

--- a/pajbot/modules/pnsl.py
+++ b/pajbot/modules/pnsl.py
@@ -65,6 +65,7 @@ class PNSLModule(BaseModule):
         if self.settings["offline_only"] is True:
             if not self.bot.is_online:
                 bot.whisper(source, f"{bot.streamer} is online! Skipping PNSL list eval.")
+                return False
 
         base_url = "https://bot.tetyys.com/api/v1/BotLists"
 

--- a/pajbot/modules/pnsl.py
+++ b/pajbot/modules/pnsl.py
@@ -17,6 +17,13 @@ class PNSLModule(BaseModule):
     CATEGORY = "Moderation"
     SETTINGS = [
         ModuleSetting(
+            key="offline_only",
+            label="Only allow the PNSL commands to be run while the stream is offline",
+            type="boolean",
+            required=True,
+            default=False,
+        ),
+        ModuleSetting(
             key="level",
             label="Level required to use the command",
             type="number",
@@ -55,8 +62,9 @@ class PNSLModule(BaseModule):
                 self.pnsl_token = bot.config["pnsl"].get("token", None)
 
     def run_pnsl(self, bot, source, message, event, args):
-        if not self.bot.is_online:
-            bot.whisper(source, f"{bot.streamer} is online! Skipping P&SL list eval.")
+        if self.settings["offline_only"] is True:
+            if not self.bot.is_online:
+                bot.whisper(source, f"{bot.streamer} is online! Skipping PNSL list eval.")
 
         base_url = "https://bot.tetyys.com/api/v1/BotLists"
 

--- a/pajbot/modules/pnsl.py
+++ b/pajbot/modules/pnsl.py
@@ -55,6 +55,9 @@ class PNSLModule(BaseModule):
                 self.pnsl_token = bot.config["pnsl"].get("token", None)
 
     def run_pnsl(self, bot, source, message, event, args):
+        if not self.bot.is_online:
+            bot.whisper(source, f"{bot.streamer} is online! Skipping P&SL list eval.")
+
         base_url = "https://bot.tetyys.com/api/v1/BotLists"
 
         if not self.pnsl_token:


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

PNSL lists should not be run while the streamer is online. This will aid for users who opt to use the controlling channel for running these lists.
