### PR TITLE
Fix new P&SL list parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
+- Bugfix: Handle new format of P&SL lists (#988, #989)
+
 ## v1.47
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!

--- a/pajbot/modules/pnsl.py
+++ b/pajbot/modules/pnsl.py
@@ -83,7 +83,7 @@ class PNSLModule(BaseModule):
             bot.whisper(source, f"Something went wrong with the P&SL request: {error_data['errors']['Guid'][0]}")
             return False
 
-        privmsg_list = res.text.splitlines()
+        privmsg_list = res.text.split("\n")
 
         log.info(f"[P&SL] User {source.name} running list {guid} with {len(privmsg_list)} entries")
 

--- a/pajbot/modules/pnsl.py
+++ b/pajbot/modules/pnsl.py
@@ -73,6 +73,7 @@ class PNSLModule(BaseModule):
             return False
 
         guid = message.replace("https://bot.tetyys.com/BotList/", "")
+        guid = message.replace("https://bot.tetyys.com/api/v1/BotList/", "")
 
         headers = {"Authorization": f"Bearer {self.pnsl_token}"}
 


### PR DESCRIPTION
When fetching a PNSL list, split on the Line Feed character (\n) instead of using the splitlines helper.

Fixes #988 

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
