### PR TITLE
Migrate Game/Title fetching from Kraken v5 to Helix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 ## Unversioned
 
+Because the Game/Title setting API calls are now using the Helix calls, it's no longer possible to use the Bot token to update the game/title of a channel, instead the Streamer token **must** be used. In addition to this, the Streamer token needs a new permission `user:edit:broadcast`.  
+In short: The Streamers must re-authenticate with the `/streamer_login` endpoint for `!setgame` and `!settitle` to work.
+
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
+- Breaking: Replace Kraken Game/Title setting API calls with Helix ones. (#1001)
 - Minor: Added option to select your referred gambling command. (#1067)
 - Minor: The `sub_only` command option will now show in the `!debug command` command. (#1027)
 - Minor: The permaban module will now ban immediately on command use (#1014)
 - Minor: Added settings to change command name and cooldowns for showemote module. (#1007)
+- Minor: Replace Kraken Game/Title/Stream/Video fetching API calls with Helix ones (#1001)
 - Minor: Removed excess message in whisper for paid timeout module. (#993)
 - Minor: Move the streamer image resizing to the css file. Also added a rounded border to it. (#992)
 - Minor: Added user-specific cooldown to playsound module (#888, #1006)

--- a/pajbot/apiwrappers/base.py
+++ b/pajbot/apiwrappers/base.py
@@ -95,3 +95,6 @@ class BaseAPI:
 
     def put(self, endpoint, params=None, headers=None, json=None, **request_options):
         return self.request("PUT", endpoint, params, headers, json, **request_options).json()
+
+    def patch(self, endpoint, params=None, headers=None, json=None, **request_options):
+        return self.request("PATCH", endpoint, params, headers, json, **request_options)

--- a/pajbot/apiwrappers/twitch/base.py
+++ b/pajbot/apiwrappers/twitch/base.py
@@ -78,3 +78,6 @@ class BaseTwitchAPI(BaseAPI):
 
     def put(self, endpoint, params=None, headers=None, authorization=None, json=None):
         return self.request("PUT", endpoint, params, headers, authorization, json).json()
+
+    def patch(self, endpoint, params=None, headers=None, authorization=None, json=None):
+        return self.request("PATCH", endpoint, params, headers, authorization, json)

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -478,7 +478,7 @@ class TwitchHelixAPI(BaseTwitchAPI):
         return self.cache.cache_bulk_fetch_fn(
             game_ids,
             redis_key_fn=lambda game_id: f"api:twitch:helix:game:by-id:{game_id}",
-            fetch_fn=lambda user_ids: self._fetch_games("id", game_ids),
+            fetch_fn=lambda game_ids: self._fetch_games("id", game_ids),
             serializer=ClassInstanceSerializer(TwitchGame),
             expiry=lambda response: 300 if response is None else 7200,
         )
@@ -487,7 +487,7 @@ class TwitchHelixAPI(BaseTwitchAPI):
         return self.cache.cache_bulk_fetch_fn(
             game_names,
             redis_key_fn=lambda game_name: f"api:twitch:helix:game:by-name:{game_name}",
-            fetch_fn=lambda user_ids: self._fetch_games("name", game_names),
+            fetch_fn=lambda game_names: self._fetch_games("name", game_names),
             serializer=ClassInstanceSerializer(TwitchGame),
             expiry=lambda response: 300 if response is None else 7200,
         )

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 
 import logging
 import time
@@ -9,7 +9,7 @@ import math
 from requests import HTTPError
 
 from pajbot import utils
-from pajbot.apiwrappers.response_cache import DateTimeSerializer, ClassInstanceSerializer
+from pajbot.apiwrappers.response_cache import DateTimeSerializer, ClassInstanceSerializer, ListSerializer
 from pajbot.apiwrappers.twitch.base import BaseTwitchAPI
 from pajbot.models.user import UserBasics, UserChannelInformation, UserStream
 from pajbot.utils import iterate_in_chunks
@@ -17,6 +17,75 @@ from pajbot.utils import iterate_in_chunks
 log = logging.getLogger(__name__)
 
 
+class TwitchVideo:
+    def __init__(
+        self,
+        id: str,
+        user_id: str,
+        user_name: str,
+        title: str,
+        description: str,
+        created_at: str,
+        published_at: str,
+        url: str,
+        thumbnail_url: str,
+        viewable: str,
+        view_count: int,
+        language: str,
+        video_type: str,
+        duration: str,
+    ):
+        self.id: str = id
+        self.user_id: str = user_id
+        self.user_name: str = user_name
+        self.title: str = title
+        self.description: str = description
+        self.created_at: str = created_at
+        self.published_at: str = published_at
+        self.url: str = url
+        self.thumbnail_url: str = thumbnail_url
+        self.viewable: str = viewable
+        self.view_count: int = view_count
+        self.language: str = language
+        self.video_type: str = video_type
+        self.duration: str = duration
+
+    def jsonify(self):
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "user_name": self.user_name,
+            "title": self.title,
+            "description": self.description,
+            "created_at": self.created_at,
+            "published_at": self.published_at,
+            "url": self.url,
+            "thumbnail_url": self.thumbnail_url,
+            "viewable": self.viewable,
+            "view_count": self.view_count,
+            "language": self.language,
+            "video_type": self.video_type,
+            "duration": self.duration,
+        }
+
+    @staticmethod
+    def from_json(json_data):
+        return TwitchVideo(
+            json_data["id"],
+            json_data["user_id"],
+            json_data["user_name"],
+            json_data["title"],
+            json_data["description"],
+            json_data["created_at"],
+            json_data["published_at"],
+            json_data["url"],
+            json_data["thumbnail_url"],
+            json_data["viewable"],
+            json_data["view_count"],
+            json_data["language"],
+            json_data["video_type"],
+            json_data["duration"],
+        )
 
 
 class TwitchHelixAPI(BaseTwitchAPI):
@@ -305,7 +374,11 @@ class TwitchHelixAPI(BaseTwitchAPI):
         stream = response["data"][0]
 
         return UserStream(
-            stream["viewer_count"], stream["game_id"], stream["title"], stream["started_at"], stream["id"],
+            stream["viewer_count"],
+            stream["game_id"],
+            stream["title"],
+            stream["started_at"],
+            stream["id"],
         )
 
     def get_stream_by_user_id(self, user_id) -> UserStream:
@@ -313,5 +386,40 @@ class TwitchHelixAPI(BaseTwitchAPI):
             redis_key=f"api:twitch:helix:stream:by-id:{user_id}",
             fetch_fn=lambda: self._fetch_stream_by_user_id(user_id),
             serializer=ClassInstanceSerializer(UserStream),
+            expiry=lambda response: 30 if response is None else 300,
+        )
+
+    def _fetch_videos_by_user_id(self, user_id) -> List[TwitchVideo]:
+        response = self.get("/videos", {"user_id": user_id})
+
+        videos = []
+
+        for video in response["data"]:
+            videos.append(
+                TwitchVideo(
+                    video["id"],
+                    video["user_id"],
+                    video["user_name"],
+                    video["title"],
+                    video["description"],
+                    video["created_at"],
+                    video["published_at"],
+                    video["url"],
+                    video["thumbnail_url"],
+                    video["viewable"],
+                    video["view_count"],
+                    video["language"],
+                    video["type"],
+                    video["duration"],
+                )
+            )
+
+        return videos
+
+    def get_videos_by_user_id(self, user_id) -> List[TwitchVideo]:
+        return self.cache.cache_fetch_fn(
+            redis_key=f"api:twitch:helix:videos:by-id:{user_id}",
+            fetch_fn=lambda: self._fetch_videos_by_user_id(user_id),
+            serializer=ListSerializer(TwitchVideo),
             expiry=lambda response: 30 if response is None else 300,
         )

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Dict, Optional, List
 
 import logging
 import time
@@ -501,3 +501,35 @@ class TwitchHelixAPI(BaseTwitchAPI):
             return None
 
         return games[0]
+
+    def modify_channel_information(
+        self, broadcaster_id: str, game_id: str = None, title: str = None, authorization=None
+    ) -> bool:
+        body: Dict[str, str] = {}
+
+        if game_id:
+            body["game_id"] = game_id
+
+        if title:
+            body["title"] = title
+
+        if not body:
+            log.error(
+                "Invalid call to modify_channel_information, missing query parameter(s). game_id or title must be specified"
+            )
+            return False
+
+        try:
+            response = self.patch(
+                "/channels", {"broadcaster_id": broadcaster_id}, authorization=authorization, json=body
+            )
+        except HTTPError as e:
+            if e.response.status_code == 400:
+                log.error(
+                    "Invalid call to modify_channel_information, missing query parameter(s). game_id or title must be specified"
+                )
+                return False
+
+            raise e
+
+        return response.status_code == 204

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -451,8 +451,8 @@ class TwitchHelixAPI(BaseTwitchAPI):
             expiry=lambda response: 30 if response is None else 300,
         )
 
-    def _fetch_games(self, key_type, lookup_keys) -> List[TwitchGame]:
-        all_entries: List[TwitchGame] = []
+    def _fetch_games(self, key_type, lookup_keys) -> List[Optional[TwitchGame]]:
+        all_entries: List[Optional[TwitchGame]] = []
 
         # We can fetch a maximum of 100 users on each helix request
         # so we do it in chunks of 100
@@ -465,8 +465,12 @@ class TwitchHelixAPI(BaseTwitchAPI):
 
             # then fill in the gaps with None
             for lookup_key in lookup_keys_chunk:
-                value: TwitchGame = TwitchGame(**response_map.get(lookup_key, None))
-                all_entries.append(value)
+                game_dict = response_map.get(lookup_key, None)
+                if game_dict is None:
+                    all_entries.append(None)
+                else:
+                    value: TwitchGame = TwitchGame(**response_map.get(lookup_key, None))
+                    all_entries.append(value)
 
         return all_entries
 

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -391,12 +391,12 @@ class TwitchHelixAPI(BaseTwitchAPI):
 
         return clip_id
 
-    def _fetch_stream_by_user_id(self, user_id) -> UserStream:
+    def _fetch_stream_by_user_id(self, user_id) -> Optional[UserStream]:
         response = self.get("/streams", {"user_id": user_id})
 
         if len(response["data"]) <= 0:
             # Stream is offline
-            return UserStream.offline()
+            return None
 
         stream = response["data"][0]
 
@@ -408,7 +408,7 @@ class TwitchHelixAPI(BaseTwitchAPI):
             stream["id"],
         )
 
-    def get_stream_by_user_id(self, user_id) -> UserStream:
+    def get_stream_by_user_id(self, user_id) -> Optional[UserStream]:
         return self.cache.cache_fetch_fn(
             redis_key=f"api:twitch:helix:stream:by-id:{user_id}",
             fetch_fn=lambda: self._fetch_stream_by_user_id(user_id),

--- a/pajbot/apiwrappers/twitch/kraken_v5.py
+++ b/pajbot/apiwrappers/twitch/kraken_v5.py
@@ -19,53 +19,6 @@ class TwitchKrakenV5API(BaseTwitchAPI):
     def default_authorization(self):
         return self.client_credentials
 
-    def get_stream_status(self, user_id):
-        data = self.get(["streams", user_id])
-
-        def rest_data_offline():
-            return {
-                "viewers": -1,
-                "game": None,
-                "title": None,
-                "created_at": None,
-                "followers": -1,
-                "views": -1,
-                "broadcast_id": None,
-            }
-
-        def rest_data_online():
-            stream = data["stream"]
-
-            return {
-                "viewers": stream["viewers"],
-                "game": stream["game"],
-                "title": stream["channel"]["status"],
-                "created_at": stream["created_at"],
-                "followers": stream["channel"]["followers"],
-                "views": stream["channel"]["views"],
-                "broadcast_id": stream["_id"],
-            }
-
-        online = "stream" in data and data["stream"] is not None
-
-        def rest_data():
-            nonlocal online
-            if online:
-                return rest_data_online()
-            else:
-                return rest_data_offline()
-
-        return {"online": online, **rest_data()}
-
-    def set_game(self, user_id, game, authorization):
-        self.put(["channels", user_id], json={"channel": {"game": game}}, authorization=authorization)
-
-    def set_title(self, user_id, title, authorization):
-        self.put(["channels", user_id], json={"channel": {"status": title}}, authorization=authorization)
-
-    def get_vod_videos(self, channel_name):
-        return self.get(["channels", channel_name, "videos"], {"broadcast_type": "archive"})
-
     def fetch_global_emotes(self):
         # circular import prevention
         from pajbot.managers.emote import EmoteManager

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -130,7 +130,7 @@ class Bot:
         self.twitch_id_api = TwitchIDAPI(self.api_client_credentials)
         self.twitch_tmi_api = TwitchTMIAPI()
         self.app_token_manager = AppAccessTokenManager(self.twitch_id_api, RedisManager.get())
-        self.twitch_helix_api = TwitchHelixAPI(RedisManager.get(), self.app_token_manager)
+        self.twitch_helix_api: TwitchHelixAPI = TwitchHelixAPI(RedisManager.get(), self.app_token_manager)
         self.twitch_v5_api = TwitchKrakenV5API(self.api_client_credentials, RedisManager.get())
 
         self.bot_user_id = self.twitch_helix_api.get_user_id(self.nickname)

--- a/pajbot/managers/emote.py
+++ b/pajbot/managers/emote.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import logging
 
 import random
@@ -15,7 +17,7 @@ log = logging.getLogger(__name__)
 class GenericChannelEmoteManager:
     # to be implemented
     api = None
-    friendly_name = None
+    friendly_name: Optional[str] = None
 
     def __init__(self):
         self._global_emotes = []
@@ -90,7 +92,7 @@ class TwitchEmoteManager(GenericChannelEmoteManager):
 
         super().__init__()
 
-    @property
+    @property  # type: ignore
     def channel_emotes(self):
         return self.tier_one_emotes
 

--- a/pajbot/managers/handler.py
+++ b/pajbot/managers/handler.py
@@ -1,3 +1,5 @@
+from typing import Dict, Any
+
 import logging
 import operator
 
@@ -7,7 +9,7 @@ log = logging.getLogger("pajbot")
 
 
 class HandlerManager:
-    handlers = {}
+    handlers: Dict[Any, Any] = {}
 
     @staticmethod
     def init_handlers():

--- a/pajbot/managers/twitter.py
+++ b/pajbot/managers/twitter.py
@@ -1,3 +1,5 @@
+from typing import List, Any
+
 import datetime
 import logging
 import threading
@@ -208,7 +210,7 @@ class TwitterManager(GenericTwitterManager):
 
 # PBTwitterManager reads live tweets from a pajbot tweet-provider (https://github.com/pajbot/tweet-provider) instead of Twitter's streaming API
 class PBTwitterManager(GenericTwitterManager):
-    relevant_users = []
+    relevant_users: List[Any] = []
     bot = None
     client = None
     tweepy = None

--- a/pajbot/managers/websocket.py
+++ b/pajbot/managers/websocket.py
@@ -1,3 +1,4 @@
+from typing import List, Any
 import json
 import logging
 import threading
@@ -7,7 +8,7 @@ log = logging.getLogger("pajbot")
 
 
 class WebSocketServer:
-    clients = []
+    clients: List[Any] = []
 
     def __init__(self, manager, port, secure=False, key_path=None, crt_path=None, unix_socket_path=None):
         self.manager = manager

--- a/pajbot/migration_revisions/db/0013_stringify_stream_chunk_id.py
+++ b/pajbot/migration_revisions/db/0013_stringify_stream_chunk_id.py
@@ -1,0 +1,2 @@
+def up(cursor, bot):
+    cursor.execute("ALTER TABLE stream_chunk ALTER COLUMN broadcast_id TYPE TEXT")

--- a/pajbot/models/action.py
+++ b/pajbot/models/action.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import collections
 import json
 import logging
@@ -142,8 +144,8 @@ class SubstitutionFilter:
 
 
 class BaseAction:
-    type = None
-    subtype = None
+    type: Optional[str] = None
+    subtype: Optional[str] = None
 
     def reset(self):
         pass

--- a/pajbot/models/hsbet.py
+++ b/pajbot/models/hsbet.py
@@ -42,7 +42,7 @@ class HSBetGame(Base):
     def is_running(self):
         return self.outcome is None
 
-    @is_running.expression
+    @is_running.expression  # type: ignore
     def is_running(self):
         return self.outcome.is_(None)
 
@@ -50,7 +50,7 @@ class HSBetGame(Base):
     def betting_open(self):
         return self.is_running and self.bet_deadline is not None and self.bet_deadline >= utils.now()
 
-    @betting_open.expression
+    @betting_open.expression  # type: ignore
     def betting_open(self):
         return and_(self.is_running, self.bet_deadline.isnot(None), self.bet_deadline >= functions.now())
 

--- a/pajbot/models/stream.py
+++ b/pajbot/models/stream.py
@@ -332,7 +332,6 @@ class StreamManager:
         if self.current_stream_chunk is None or self.current_stream is None:
             return
 
-        log.info(f"Attempting to fetch video url for broadcast {self.current_stream_chunk.broadcast_id}")
         video: Optional[TwitchVideo] = self.fetch_video_url_stage2(data)
 
         if video is None:

--- a/pajbot/models/stream.py
+++ b/pajbot/models/stream.py
@@ -1,6 +1,6 @@
 import logging
 
-from sqlalchemy import BIGINT, BOOLEAN, INT, TEXT
+from sqlalchemy import BOOLEAN, INT, TEXT
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import relationship
@@ -52,7 +52,7 @@ class StreamChunk(Base):
 
     id = Column(INT, primary_key=True)
     stream_id = Column(INT, ForeignKey("stream.id", ondelete="CASCADE"), nullable=False)
-    broadcast_id = Column(BIGINT, nullable=False)
+    broadcast_id = Column(TEXT, nullable=False)
     video_url = Column(TEXT, nullable=True)
     video_preview_image_url = Column(TEXT, nullable=True)
     chunk_start = Column(UtcDateTime(), nullable=False)

--- a/pajbot/models/stream.py
+++ b/pajbot/models/stream.py
@@ -131,6 +131,11 @@ class StreamManager:
             self.refresh_channel_information,
         )
 
+        self.bot.execute_now(
+            self.bot.action_queue.submit,
+            self.refresh_channel_information,
+        )
+
         # Polls Helix's "Get Streams" endpoint and updates the liveness of the stream.
         # If the stream is live, we also update some data such as title and stream id
         self.bot.execute_every(

--- a/pajbot/models/stream.py
+++ b/pajbot/models/stream.py
@@ -1,5 +1,7 @@
 import logging
 
+from typing import Optional, List
+
 from sqlalchemy import BOOLEAN, INT, TEXT
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
@@ -9,10 +11,13 @@ from sqlalchemy_utc import UtcDateTime
 from pajbot import utils
 from pajbot.apiwrappers.base import BaseAPI
 from pajbot.apiwrappers.twitch.base import BaseTwitchAPI
+from pajbot.apiwrappers.twitch.helix import TwitchVideo, TwitchGame
 from pajbot.managers.db import Base
 from pajbot.managers.db import DBManager
 from pajbot.managers.handler import HandlerManager
 from pajbot.managers.redis import RedisManager
+
+from pajbot.models.user import UserStream, UserChannelInformation
 
 log = logging.getLogger("pajbot")
 
@@ -72,49 +77,64 @@ class StreamChunk(Base):
 
 class StreamManager:
     NUM_OFFLINES_REQUIRED = 10
-    STATUS_CHECK_INTERVAL = 20  # seconds
-    VIDEO_URL_CHECK_INTERVAL = 60 * 5  # seconds
+    CHANNEL_INFORMATION_CHECK_INTERVAL = 120  # seconds (Every 2 minutes)
+    STATUS_CHECK_INTERVAL = 20  # seconds (Every 20 seconds)
+    VIDEO_URL_CHECK_INTERVAL = 300  # seconds (Every 5 minutes)
 
-    def fetch_video_url_stage1(self):
+    def fetch_video_url_stage1(self) -> None:
         if self.online is False:
             return
 
-        data = self.bot.twitch_v5_api.get_vod_videos(self.bot.streamer_user_id)
+        data = self.bot.twitch_helix_api.get_videos_by_user_id(self.bot.streamer_user_id)
         self.bot.execute_now(self.refresh_video_url_stage2, data)
 
-    def fetch_video_url_stage2(self, data):
-        stream_chunk = self.current_stream_chunk if self.current_stream_chunk.video_url is None else None
+    def fetch_video_url_stage2(self, data: List[TwitchVideo]) -> Optional[TwitchVideo]:
+        if self.current_stream_chunk is None:
+            # Nothing to update
+            return None
+
+        if self.current_stream_chunk.video_url is not None:
+            # Stream chunk already has a video url
+            return None
+
         try:
-            for video in data["videos"]:
-                if video["broadcast_type"] == "archive":
+            for video in data:
+                if video.video_type == "archive":
                     continue
-                recorded_at = BaseTwitchAPI.parse_datetime(video["recorded_at"])
-                if stream_chunk is not None:
-                    time_diff = stream_chunk.chunk_start - recorded_at
-                    if abs(time_diff.total_seconds()) < 60 * 5:
-                        # we found the relevant video!
-                        return video["url"], video["preview"]["large"], video["recorded_at"]
-                else:
-                    if video["status"] == "recording":
-                        return video["url"], video["preview"]["large"], video["recorded_at"]
+                recorded_at = BaseTwitchAPI.parse_datetime(video.created_at)
+                time_diff = self.current_stream_chunk.chunk_start - recorded_at
+                if abs(time_diff.total_seconds()) < 60 * 5:
+                    # we found the relevant video!
+                    return video
         except:
             log.exception("Uncaught exception in fetch_video_url")
 
-        return None, None, None
+        return None
 
     def __init__(self, bot):
         self.bot = bot
 
-        self.current_stream_chunk = None  # should this even exist?
+        self.current_stream_chunk: Optional[StreamChunk] = None  # should this even exist?
+        self.current_stream: Optional[Stream] = None
 
-        self.num_offlines = 0
+        self.num_offlines: int = 0
         self.first_offline = None
 
-        self.num_viewers = 0
+        self.num_viewers: int = 0
 
-        self.game = "Loading..."
-        self.title = "Loading..."
+        self.game: str = "Loading..."
+        self.title: str = "Loading..."
 
+        # Polls Helix's "Get Channel Information" endpoint and updates the StreamManagers game name & title
+        # Works if stream is online or offline
+        self.bot.execute_every(
+            self.CHANNEL_INFORMATION_CHECK_INTERVAL,
+            self.bot.action_queue.submit,
+            self.refresh_channel_information,
+        )
+
+        # Polls Helix's "Get Streams" endpoint and updates the liveness of the stream.
+        # If the stream is live, we also update some data such as title and stream id
         self.bot.execute_every(
             self.STATUS_CHECK_INTERVAL, self.bot.action_queue.submit, self.refresh_stream_status_stage1
         )
@@ -150,19 +170,23 @@ class StreamManager:
     def commit():
         log.info("commiting something?")
 
-    def create_stream_chunk(self, status):
+    def create_stream_chunk(self, status: UserStream):
+        if self.current_stream is None:
+            log.warn("create_stream_chunk called with current_stream being None")
+            return
+
         if self.current_stream_chunk is not None:
             # There's already a stream chunk started!
             self.current_stream_chunk.chunk_end = utils.now()
             DBManager.session_add_expunge(self.current_stream_chunk)
 
-        stream_chunk = None
+        stream_chunk: Optional[StreamChunk] = None
 
         with DBManager.create_session_scope(expire_on_commit=False) as db_session:
-            stream_chunk = db_session.query(StreamChunk).filter_by(broadcast_id=status["broadcast_id"]).one_or_none()
+            stream_chunk = db_session.query(StreamChunk).filter_by(broadcast_id=status.id).one_or_none()
             if stream_chunk is None:
                 log.info("Creating stream chunk, from create_stream_chunk")
-                stream_chunk = StreamChunk(self.current_stream, status["broadcast_id"], status["created_at"])
+                stream_chunk = StreamChunk(self.current_stream, status.id, status.started_at)
                 self.current_stream_chunk = stream_chunk
                 db_session.add(stream_chunk)
                 db_session.commit()
@@ -175,10 +199,10 @@ class StreamManager:
         if stream_chunk:
             self.current_stream.stream_chunks.append(stream_chunk)
 
-    def create_stream(self, status):
+    def create_stream(self, status: UserStream):
         log.info("Attempting to create a stream!")
         with DBManager.create_session_scope(expire_on_commit=False) as db_session:
-            stream_chunk = db_session.query(StreamChunk).filter_by(broadcast_id=status["broadcast_id"]).one_or_none()
+            stream_chunk = db_session.query(StreamChunk).filter_by(broadcast_id=status.id).one_or_none()
             new_stream = False
             if stream_chunk is not None:
                 stream = stream_chunk.stream
@@ -189,11 +213,11 @@ class StreamManager:
 
                 if new_stream:
                     log.info("No active stream, create new!")
-                    stream = Stream(status["created_at"], title=status["title"])
+                    stream = Stream(status.started_at, title=status.title)
                     db_session.add(stream)
                     db_session.commit()
                     log.info("Successfully added stream!")
-                stream_chunk = StreamChunk(stream, status["broadcast_id"], status["created_at"])
+                stream_chunk = StreamChunk(stream, status.id, status.started_at)
                 db_session.add(stream_chunk)
                 db_session.commit()
                 stream.stream_chunks.append(stream_chunk)
@@ -227,39 +251,70 @@ class StreamManager:
 
         HandlerManager.trigger("on_stream_stop", stop_on_false=False)
 
-    def refresh_stream_status_stage1(self):
-        status = self.bot.twitch_v5_api.get_stream_status(self.bot.streamer_user_id)
-        self.bot.execute_now(self.refresh_stream_status_stage2, status)
+    def refresh_channel_information(self):
+        channel_information: Optional[UserChannelInformation] = self.bot.twitch_helix_api.get_channel_information(
+            self.bot.streamer_user_id
+        )
 
-    def refresh_stream_status_stage2(self, status):
+        if channel_information is None:
+            log.error(f"Unable to fetch channel information about {self.bot.streamer_user_id}")
+            return
+
         redis = RedisManager.get()
         key_prefix = self.bot.streamer + ":"
 
-        stream_data = {key_prefix + "online": str(status["online"]), key_prefix + "viewers": status["viewers"]}
-        if status["game"]:
-            stream_data[key_prefix + "game"] = status["game"]
-        else:
-            stream_data[key_prefix + "game"] = ""
+        stream_data = {
+            f"{key_prefix}game": channel_information.game_name,
+            f"{key_prefix}title": channel_information.title,
+        }
 
         redis.hmset("stream_data", stream_data)
 
-        self.num_viewers = status["viewers"]
-        self.game = status["game"]
-        self.title = status["title"]
+        self.game = channel_information.game_name
+        self.title = channel_information.title
 
-        if status["online"]:
+    def refresh_stream_status_stage1(self):
+        status: UserStream = self.bot.twitch_helix_api.get_stream_by_user_id(self.bot.streamer_user_id)
+        self.bot.execute_now(self.refresh_stream_status_stage2, status)
+
+    def refresh_stream_status_stage2(self, status: UserStream):
+        redis = RedisManager.get()
+        key_prefix = self.bot.streamer + ":"
+
+        game_info: Optional[TwitchGame] = self.bot.twitch_helix_api.get_game_by_game_id(status.game_id)
+        game_name: str = ""
+        if game_info is not None:
+            game_name = game_info.name
+
+        stream_data = {
+            f"{key_prefix}online": str(status.online),
+            f"{key_prefix}viewers": status.viewer_count,
+            f"{key_prefix}game": game_name,
+        }
+        redis.hmset("stream_data", stream_data)
+
+        self.num_viewers = status.viewer_count
+
+        self.game = game_name
+        self.title = status.title
+
+        if status.online:
+            # stream reported as online
             if self.current_stream is None:
                 self.create_stream(status)
             if self.current_stream_chunk is None:
                 self.create_stream_chunk(status)
-            if self.current_stream_chunk.broadcast_id != status["broadcast_id"]:
-                log.debug("Detected a new chunk!")
-                self.create_stream_chunk(status)
+            if self.current_stream_chunk is not None:
+                if self.current_stream_chunk.broadcast_id != status.id:
+                    log.debug(f"Detected a new chunk! {self.current_stream_chunk.broadcast_id} != {status.id}")
+                    self.create_stream_chunk(status)
 
             self.num_offlines = 0
             self.first_offline = None
         else:
+            # stream reported as offline
             if self.online is True:
+                # but we have stream marked as online.. begin the countdown
                 self.num_offlines += 1
                 log.info(f"Offline. {self.num_offlines}")
                 if self.first_offline is None:
@@ -280,17 +335,16 @@ class StreamManager:
             return
 
         log.info(f"Attempting to fetch video url for broadcast {self.current_stream_chunk.broadcast_id}")
-        video_url, video_preview_image_url, video_recorded_at = self.fetch_video_url_stage2(data)
+        video: Optional[TwitchVideo] = self.fetch_video_url_stage2(data)
 
-        if video_url is None:
-            log.info("No video for broadcast found")
+        if video is None:
             return
 
-        log.info(f"Successfully fetched a video url: {video_url}")
+        log.info(f"Successfully fetched a video url: {video.url}")
         if self.current_stream_chunk is None or self.current_stream_chunk.video_url is None:
             with DBManager.create_session_scope(expire_on_commit=False) as db_session:
-                self.current_stream_chunk.video_url = video_url
-                self.current_stream_chunk.video_preview_image_url = video_preview_image_url
+                self.current_stream_chunk.video_url = video.url
+                self.current_stream_chunk.video_preview_image_url = video.thumbnail_url
 
                 db_session.add(self.current_stream_chunk)
 
@@ -298,18 +352,18 @@ class StreamManager:
 
                 db_session.expunge_all()
             log.info("Successfully commited video url data.")
-        elif self.current_stream_chunk.video_url != video_url:
+        elif self.current_stream_chunk.video_url != video.url:
             # End current stream chunk
             self.current_stream_chunk.chunk_end = utils.now()
             DBManager.session_add_expunge(self.current_stream_chunk)
 
             with DBManager.create_session_scope(expire_on_commit=False) as db_session:
                 stream_chunk = StreamChunk(
-                    self.current_stream, self.current_stream_chunk.broadcast_id, video_recorded_at
+                    self.current_stream, self.current_stream_chunk.broadcast_id, video.recorded_at
                 )
                 self.current_stream_chunk = stream_chunk
-                self.current_stream_chunk.video_url = video_url
-                self.current_stream_chunk.video_preview_image_url = video_preview_image_url
+                self.current_stream_chunk.video_url = video.url
+                self.current_stream_chunk.video_preview_image_url = video.thumbnail_url
 
                 db_session.add(self.current_stream_chunk)
 

--- a/pajbot/models/stream.py
+++ b/pajbot/models/stream.py
@@ -99,8 +99,6 @@ class StreamManager:
 
         try:
             for video in data:
-                if video.video_type == "archive":
-                    continue
                 recorded_at = BaseTwitchAPI.parse_datetime(video.created_at)
                 time_diff = self.current_stream_chunk.chunk_start - recorded_at
                 if abs(time_diff.total_seconds()) < 60 * 5:

--- a/pajbot/models/user.py
+++ b/pajbot/models/user.py
@@ -434,3 +434,38 @@ class UserChannelInformation:
             game_name=json_data["game_name"],
             title=json_data["title"],
         )
+
+
+class UserStream:
+    def __init__(self, viewer_count, game_id, title, started_at, id):
+        self.viewer_count = viewer_count
+        self.game_id = game_id
+        self.title = title
+        self.started_at = started_at
+        self.id = id
+
+        self.online = viewer_count > -1
+
+    @staticmethod
+    def offline():
+        return UserStream(-1, None, None, None, None)
+
+    def jsonify(self):
+        return {
+            "viewer_count": self.viewer_count,
+            "game_id": self.game_id,
+            "title": self.title,
+            "started_at": self.started_at,
+            "id": self.id,
+            "online": self.online,
+        }
+
+    @staticmethod
+    def from_json(json_data):
+        return UserStream(
+            json_data["viewer_count"],
+            json_data["game_id"],
+            json_data["title"],
+            json_data["started_at"],
+            json_data["id"],
+        )

--- a/pajbot/models/user.py
+++ b/pajbot/models/user.py
@@ -406,3 +406,31 @@ class User(Base):
     @staticmethod
     def find_by_id(db_session, id):
         return db_session.query(User).filter_by(id=id).one_or_none()
+
+
+class UserChannelInformation:
+    """UserChannelInformation represents part of the information fetched
+    from the Helix Get Channel Information endpoint https://dev.twitch.tv/docs/api/reference#get-channel-information"""
+
+    def __init__(self, broadcaster_language, game_id, game_name, title):
+        self.broadcaster_language = broadcaster_language
+        self.game_id = game_id
+        self.game_name = game_name
+        self.title = title
+
+    def jsonify(self):
+        return {
+            "broadcaster_language": self.broadcaster_language,
+            "game_id": self.game_id,
+            "game_name": self.game_name,
+            "title": self.title,
+        }
+
+    @staticmethod
+    def from_json(json_data):
+        return UserChannelInformation(
+            broadcaster_language=json_data["broadcaster_language"],
+            game_id=json_data["game_id"],
+            game_name=json_data["game_name"],
+            title=json_data["title"],
+        )

--- a/pajbot/models/user.py
+++ b/pajbot/models/user.py
@@ -444,12 +444,6 @@ class UserStream:
         self.started_at = started_at
         self.id = id
 
-        self.online = viewer_count > -1
-
-    @staticmethod
-    def offline():
-        return UserStream(-1, None, None, None, None)
-
     def jsonify(self):
         return {
             "viewer_count": self.viewer_count,
@@ -457,7 +451,6 @@ class UserStream:
             "title": self.title,
             "started_at": self.started_at,
             "id": self.id,
-            "online": self.online,
         }
 
     @staticmethod

--- a/pajbot/models/user.py
+++ b/pajbot/models/user.py
@@ -131,7 +131,7 @@ class User(Base):
     def login(self):
         return self._login
 
-    @login.setter
+    @login.setter  # type: ignore
     def login(self, new_login):
         self._login = new_login
         # force SQLAlchemy to update the value in the database even if the value did not change
@@ -170,11 +170,11 @@ class User(Base):
     def timed_out(self):
         return self.timeout_end is not None and self.timeout_end > utils.now()
 
-    @timed_out.expression
+    @timed_out.expression  # type: ignore
     def timed_out(self):
         return and_(self.timeout_end.isnot(None), self.timeout_end > functions.now())
 
-    @timed_out.setter
+    @timed_out.setter  # type: ignore
     def timed_out(self, timed_out):
         # You can do user.timed_out = False to set user.timeout_end = None
         if timed_out is not False:

--- a/pajbot/modules/banphrase.py
+++ b/pajbot/modules/banphrase.py
@@ -1,3 +1,5 @@
+from typing import List, Any
+
 import logging
 
 from pajbot.managers.adminlog import AdminLogManager
@@ -17,7 +19,7 @@ class BanphraseModule(BaseModule):
     DESCRIPTION = "Looks at each message for banned phrases, and takes actions accordingly"
     ENABLED_DEFAULT = True
     CATEGORY = "Moderation"
-    SETTINGS = []
+    SETTINGS: List[Any] = []
 
     def is_message_bad(self, source, msg_raw, _event):
         res = self.bot.banphrase_manager.check_message(msg_raw, source)

--- a/pajbot/modules/base.py
+++ b/pajbot/modules/base.py
@@ -1,9 +1,12 @@
+from typing import Optional, Any, List
+
 import json
 import logging
 
 from pajbot.managers.db import DBManager
 from pajbot.models.module import Module
 from pajbot.utils import find
+from pajbot.bot import Bot
 
 log = logging.getLogger(__name__)
 
@@ -104,22 +107,22 @@ class BaseModule:
         + "It's what will be shown on the website where you can enable "
         + "and disable modules."
     )
-    SETTINGS = []
+    SETTINGS: List[Any] = []
     ENABLED_DEFAULT = False
-    PARENT_MODULE = None
+    PARENT_MODULE: Optional[Any] = None
     CATEGORY = "Uncategorized"
     HIDDEN = False
     MODULE_TYPE = ModuleType.TYPE_NORMAL
     CONFIGURE_LEVEL = 500
 
-    def __init__(self, bot):
+    def __init__(self, bot: Bot):
         """ Initialize any dictionaries the module might or might not use. """
-        self.bot = bot
+        self.bot: Bot = bot
 
-        self.commands = {}
+        self.commands: Any = {}
         self.default_settings = {}
-        self.settings = {}
-        self.submodules = []
+        self.settings: Any = {}
+        self.submodules: Any = []
         self.parent_module = None
 
         # We store a dictionary with the default settings for convenience

--- a/pajbot/modules/linktracker.py
+++ b/pajbot/modules/linktracker.py
@@ -1,3 +1,5 @@
+from typing import List, Any
+
 import logging
 from urllib.parse import urlsplit
 
@@ -44,7 +46,7 @@ class LinkTrackerModule(BaseModule):
     DESCRIPTION = "Tracks chat to see which links are most frequently posted in your chat"
     ENABLED_DEFAULT = True
     CATEGORY = "Feature"
-    SETTINGS = []
+    SETTINGS: List[Any] = []
 
     def __init__(self, bot):
         super().__init__(bot)

--- a/pajbot/modules/pointlottery.py
+++ b/pajbot/modules/pointlottery.py
@@ -1,3 +1,5 @@
+from typing import List, Any
+
 import logging
 
 import random
@@ -14,7 +16,7 @@ class PointLotteryModule(BaseModule):
     NAME = "Point Lottery"
     DESCRIPTION = "Lets players participate in lottery for points"
     CATEGORY = "Game"
-    SETTINGS = []
+    SETTINGS: List[Any] = []
 
     def __init__(self, bot):
         super().__init__(bot)

--- a/pajbot/modules/subscriber_fetch.py
+++ b/pajbot/modules/subscriber_fetch.py
@@ -1,3 +1,5 @@
+from typing import List, Any
+
 import logging
 
 from requests import HTTPError
@@ -20,7 +22,7 @@ class SubscriberFetchModule(BaseModule):
     ENABLED_DEFAULT = True
     CATEGORY = "Internal"
     HIDDEN = True
-    SETTINGS = []
+    SETTINGS: List[Any] = []
 
     def update_subs_cmd(self, bot, source, **rest):
         # TODO if you wanted to improve this: Provide the user with feedback

--- a/pajbot/tmi.py
+++ b/pajbot/tmi.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from enum import Enum
 
 
@@ -17,6 +19,10 @@ class WhisperOutputMode(Enum):
 
 
 class TMIRateLimits:
+    BASE: Any
+    KNOWN: Any
+    VERIFIED: Any
+
     def __init__(self, privmsg_per_30, whispers_per_second, whispers_per_minute):
         self.privmsg_per_30 = privmsg_per_30
         self.whispers_per_second = whispers_per_second

--- a/pajbot/web/routes/base/login.py
+++ b/pajbot/web/routes/base/login.py
@@ -49,7 +49,7 @@ def init(app):
         "clips:edit",
     ]
 
-    streamer_scopes = ["channel:read:subscriptions", "channel_editor"]
+    streamer_scopes = ["channel:read:subscriptions", "channel_editor", "user:edit:broadcast"]
 
     @app.route("/login")
     def login():

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 black==20.8b1
 flake8==3.8.4
 pytest==6.1.2
+mypy==0.790


### PR DESCRIPTION
This PR outgrew itself a bit, instead of only doing Game/Title fetching in Helix instead of Kraken v5, we also fetch video/stream information from Helix, and we use Helix for setting Game/Title.

During development, I started using mypy for getting early warnings in case I was sending the wrong parameters in somewhere, and it spreads very easily so there's a commit that adds typing to a few things that aren't related to this migration. If needed, this can be made into its own PR (including the addition of mypy to `requirements-dev.txt`)

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

Fixes #998