### PR TITLE
Fix name of "Get timed out" quest module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Bugfix: Handle new format of P&SL lists (#988, #989)
 - Bugfix: Fixed league rank module not working at all. (#990)
 - Bugfix: Handle new format of P&SL lists (#988, #989, #994)
+- Bugfix: Fixed name of "get timed out" quest. (It just said "Quest" before) (#1003)
 
 ## v1.47
 

--- a/pajbot/modules/quests/gettimedout.py
+++ b/pajbot/modules/quests/gettimedout.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 class GetTimedOutQuestModule(BaseQuest):
 
     ID = "quest-" + __name__.split(".")[-1]
-    NAME = "Quest"
+    NAME = "Get timed out"
     DESCRIPTION = "Get timed out by someone"
     PARENT_MODULE = QuestModule
     OBJECTIVE = "Get timed out by another user"


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1629196/91632954-d72bab00-e9e4-11ea-9fe2-d87f8dc393cb.png)


Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
