### PR TITLE
Ignore the vscode-server folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ venv/
 
 .idea/
 .vscode/
+.vscode-server/

--- a/.prettierignore
+++ b/.prettierignore
@@ -29,6 +29,7 @@ venv/
 
 .idea/
 .vscode/
+.vscode-server/
 /.github/pull_request_template.md
 
 # Ignore generated code


### PR DESCRIPTION
Sometimes I work with the remote ssh tool in vscode and prettier likes to reformat it. This will be good for other people that use the extension

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable