### PR TITLE
Change error code for helix clip error 503

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ In short: The Streamers must re-authenticate with the `/streamer_login` endpoint
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
 - Breaking: Replace Kraken Game/Title setting API calls with Helix ones. (#1001)
+- Minor: Changed 503 error code message for the clip helix endpoint. (#1091)
 - Minor: Added option to select your referred gambling command. (#1067)
 - Minor: The `sub_only` command option will now show in the `!debug command` command. (#1027)
 - Minor: The permaban module will now ban immediately on command use (#1014)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ In short: The Streamers must re-authenticate with the `/streamer_login` endpoint
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
 - Breaking: Replace Kraken Game/Title setting API calls with Helix ones. (#1001)
-- Minor: Changed 503 error code message for the clip helix endpoint. (#1091)
+- Minor: Bot now provides more helpful error message when `!clip` is used in a channel with clips disabled. (#1091)
 - Minor: Added option to select your referred gambling command. (#1067)
 - Minor: The `sub_only` command option will now show in the `!debug command` command. (#1027)
 - Minor: The permaban module will now ban immediately on command use (#1014)

--- a/pajbot/modules/basic/clip.py
+++ b/pajbot/modules/basic/clip.py
@@ -134,7 +134,9 @@ class ClipCommandModule(BaseModule):
                     StreamHelper.get_streamer_id(), self.bot.bot_token_manager
                 )
         except HTTPError as e:
-            if e.response.status_code != 401:
+            if e.response.status_code == 503:
+                self.bot.say(f"{source}, Failed to create clip! Does the streamer have clips disabled?")
+            elif e.response.status_code != 401:
                 self.bot.say(f"{source}, Failed to create clip! Please try again.")
             else:
                 self.bot.say(


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

Twitch decided not to implement specific error codes for channels that have clips disabled, so I've changed the error message to suggest the streamer may have clips disabled. Problem is, as per [this link](https://discuss.dev.twitch.tv/t/helix-create-clip-503-unavailable/20362), it could also simply be twitch being shit.

In saying that, suggesting the user try clipping again isn't a great way to solve twitch's servers/backend being down. So this somewhat solves 2 problems.

Specifically zoro had clips disabled and I didn't realise. So there I was, continually using the command unknowingly.
![image](https://user-images.githubusercontent.com/12804673/101277214-8525cd00-37fe-11eb-8ac7-241d67326d85.png)