### PR TITLE
Banphrase module changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ In short: The Streamers must re-authenticate with the `/streamer_login` endpoint
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
 - Breaking: Replace Kraken Game/Title setting API calls with Helix ones. (#1001)
+- Minor: Set the banphrase module to hidden + always enabled.
 - Minor: Bot now provides more helpful error message when `!clip` is used in a channel with clips disabled. (#1091)
 - Minor: Added custom message options to the LastFM module. (#1090)
 - Minor: Added customizable cooldowns to the LastFM module. (#1090)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ In short: The Streamers must re-authenticate with the `/streamer_login` endpoint
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
 - Breaking: Replace Kraken Game/Title setting API calls with Helix ones. (#1001)
-- Minor: Set the banphrase module to hidden + always enabled.
+- Minor: Set the banphrase module to hidden + always enabled. (#1093)
 - Minor: Bot now provides more helpful error message when `!clip` is used in a channel with clips disabled. (#1091)
 - Minor: Added custom message options to the LastFM module. (#1090)
 - Minor: Added customizable cooldowns to the LastFM module. (#1090)

--- a/pajbot/modules/banphrase.py
+++ b/pajbot/modules/banphrase.py
@@ -17,6 +17,8 @@ class BanphraseModule(BaseModule):
     NAME = "Banphrases"
     DESCRIPTION = "Looks at each message for banned phrases, and takes actions accordingly"
     ENABLED_DEFAULT = True
+    HIDDEN = True
+    MODULE_TYPE = ModuleType.TYPE_ALWAYS_ENABLED
     CATEGORY = "Moderation"
     SETTINGS: List[Any] = []
 

--- a/pajbot/modules/banphrase.py
+++ b/pajbot/modules/banphrase.py
@@ -5,9 +5,8 @@ import logging
 from pajbot.managers.adminlog import AdminLogManager
 from pajbot.managers.db import DBManager
 from pajbot.managers.handler import HandlerManager
-from pajbot.models.command import Command
-from pajbot.models.command import CommandExample
 from pajbot.modules.base import BaseModule
+from pajbot.models.command import Command, CommandExample
 
 log = logging.getLogger(__name__)
 

--- a/pajbot/modules/banphrase.py
+++ b/pajbot/modules/banphrase.py
@@ -5,8 +5,8 @@ import logging
 from pajbot.managers.adminlog import AdminLogManager
 from pajbot.managers.db import DBManager
 from pajbot.managers.handler import HandlerManager
-from pajbot.modules.base import BaseModule
 from pajbot.models.command import Command, CommandExample
+from pajbot.modules.base import BaseModule, ModuleType
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

I don't think there's a reason for the banphrase module to be displayed in the modules list. If you don't want banphrases, then don't add them; there's no reason to have the option to enable/disable the module.