### PR TITLE
Fix double message handling in safe_privmsg and is_bad_message functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Minor: Fixed double banphrase handling in the `safe_privmsg` function and `is_bad_message` function.
+- Minor: Fixed double banphrase handling in the `safe_privmsg` function and `is_bad_message` function. (#1122)
 
 ## v1.48
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Minor: Fixed double banphrase handling in the `safe_privmsg` function and `is_bad_message` function.
+
 ## v1.48
 
 Because the Game/Title setting API calls are now using the Helix calls, it's no longer possible to use the Bot token to update the game/title of a channel, instead the Streamer token **must** be used. In addition to this, the Streamer token needs a new permission `user:edit:broadcast`.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unversioned
 
-- Minor: Fixed double banphrase handling in the `safe_privmsg` function and `is_bad_message` function. (#1122)
-
 ## v1.48
 
 Because the Game/Title setting API calls are now using the Helix calls, it's no longer possible to use the Bot token to update the game/title of a channel, instead the Streamer token **must** be used. In addition to this, the Streamer token needs a new permission `user:edit:broadcast`.  

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -625,15 +625,6 @@ class Bot:
         else:
             log.warning("Unknown send_message method: %s", method)
 
-    def safe_privmsg(self, message, channel=None):
-        # Check for banphrases
-        res = self.banphrase_manager.check_message(message, None)
-        if res is not False:
-            self.privmsg(f"filtered message ({res.id})", channel)
-            return
-
-        self.privmsg(message, channel)
-
     def say(self, message, channel=None):
         if message is None:
             log.warning("message=None passed to Bot::say()")
@@ -646,7 +637,12 @@ class Bot:
         self.privmsg(message[:510], channel)
 
     def is_bad_message(self, message):
+        # Checks for banphrases
         return self.banphrase_manager.check_message(message, None) is not False
+
+    def safe_privmsg(self, message, channel=None):
+        if not self.is_bad_message(message):
+            self.privmsg(message, channel)
 
     def safe_me(self, message, channel=None):
         if not self.is_bad_message(message):


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

Initially the `safe_privmsg` function had it's own banphrase checking in it. This isn't required as there is a specific function for checking for bad messages: `is_bad_message`. This pr removes the double banphrase handling and makes use of the function that is already in place. I've also changed the behaviour of the `safe_privmsg` function; it will now not respond to command usage if it triggers a banphrase - which replicates the behaviour of the `safe_me` function (making the bot more consistent).