### PR TITLE
Add safe say function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Minor: Added a `safe_say` function.
+
 ## v1.48
 
 Because the Game/Title setting API calls are now using the Helix calls, it's no longer possible to use the Bot token to update the game/title of a channel, instead the Streamer token **must** be used. In addition to this, the Streamer token needs a new permission `user:edit:broadcast`.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unversioned
 
-- Minor: Added a `safe_say` function. (#1123)
-
 ## v1.48
 
 Because the Game/Title setting API calls are now using the Helix calls, it's no longer possible to use the Bot token to update the game/title of a channel, instead the Streamer token **must** be used. In addition to this, the Streamer token needs a new permission `user:edit:broadcast`.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Minor: Added a `safe_say` function.
+- Minor: Added a `safe_say` function. (#1123)
 
 ## v1.48
 

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -652,6 +652,10 @@ class Bot:
         if not self.is_bad_message(message):
             self.me(message, channel)
 
+    def safe_say(self, message, channel=None):
+        if not self.is_bad_message(message):
+            self.say(message, channel)
+
     def me(self, message, channel=None):
         self.say("/me " + message[:500], channel=channel)
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

Similar to the `safe_privmsg` and `safe_me` functions, the `safe_say` function will check the response against the banphrases before posting the response. If it is a banned phrase, it won't post anything at all.