### PR TITLE
Added $(date:<timezone>) variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Minor: Added `$(date:<timezone>)` variable.
+
 ## v1.48
 
 Because the Game/Title setting API calls are now using the Helix calls, it's no longer possible to use the Bot token to update the game/title of a channel, instead the Streamer token **must** be used. In addition to this, the Streamer token needs a new permission `user:edit:broadcast`.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Minor: Added `$(date:<timezone>)` variable.
+- Minor: Added `$(date:<timezone>)` variable. (#1125)
 
 ## v1.48
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -91,6 +91,7 @@ Customapis are generally a very powerful way of allowing pajbot to do more thing
 
 `$(tb:molly_age_in_years)` - String - '0.1971333233018455' (age of pajlada's puppy molly in years)\
 `$(time:<timezone>)` - String - '18:47' (timezone is e.g. 'Europe/Berlin')
+`$(date:<timezone>)` - String - '2021-01-12' (timezone is e.g. 'Europe/Berlin')
 
 #### e - emotes
 

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -389,6 +389,13 @@ class Bot:
 
         return None
 
+    def get_date_value(self, key, extra={}):
+        try:
+            tz = timezone(key)
+            return datetime.datetime.now(tz).strftime("%Y-%m-%d")
+        except:
+            log.exception("Unhandled exception in get_date_value")
+
     def get_current_song_value(self, key, extra={}):
         if self.stream_manager.online:
             current_song = PleblistManager.get_current_song(self.stream_manager.current_stream.id)

--- a/pajbot/models/action.py
+++ b/pajbot/models/action.py
@@ -348,6 +348,7 @@ def get_substitutions(string, bot):
         method_mapping["user"] = bot.get_user_value
         method_mapping["usersource"] = bot.get_usersource_value
         method_mapping["time"] = bot.get_time_value
+        method_mapping["date"] = bot.get_date_value
         method_mapping["curdeck"] = bot.decks.action_get_curdeck
         method_mapping["stream"] = bot.stream_manager.get_stream_value
         method_mapping["current_stream"] = bot.stream_manager.get_current_stream_value


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

Added a small variable `$(date:<timezone>)` outputting in format `2021-01-13`. I decided this format is the safest, as it is an ISO standard and it shouldn't be as confusing for anyone, who's using american date format.
