### PR TITLE
Fix bad links matching

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -78,3 +78,6 @@ ignore_missing_imports = True
 
 [mypy-pajbot.userdispatch.*]
 ignore_missing_imports = True
+
+[mypy-urlextract.*]
+ignore_missing_imports = True

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Minor: Added an option to allow mass pings while the streamer is on/offline. (#1129)
 - Minor: Added an option to allow rouletting while the streamer is on/offline. (#1131)
 - Minor: Added `$(date:<timezone>)` variable. (#1125)
-- Bugfix: Fix issue where we matched some normal messages as links (e.g. 1.40 or asd...xd)
+- Bugfix: Fix issue where we matched some normal messages as links, e.g. 1.40 or asd...xd (#1148)
 
 ## v1.48
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
+
 - Major: `$(urlfetch)` now handles non-200 error codes differently by returning the body if the returned content type is plain text, or a generic "urlfetch error 404" if the content type was not plain text. (#1140)
 - Minor: Added an option to only enable slots after a re/sub. (#1146)
 - Minor: Added an option to allow ASCII characters while the streamer is on/offline. (#1145)
@@ -11,6 +13,7 @@
 - Minor: Added an option to allow mass pings while the streamer is on/offline. (#1129)
 - Minor: Added an option to allow rouletting while the streamer is on/offline. (#1131)
 - Minor: Added `$(date:<timezone>)` variable. (#1125)
+- Bugfix: Fix issue where we matched some normal messages as links (e.g. 1.40 or asd...xd)
 
 ## v1.48
 

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -51,11 +51,6 @@ from pajbot import utils
 
 log = logging.getLogger(__name__)
 
-URL_REGEX = re.compile(
-    r"\(?(?:(http|https):\/\/)?(?:((?:[^\W\s]|\.|-|[:]{1})+)@{1})?((?:www.)?(?:[^\W\s]|\.|-)+[\.][^\W\s]{2,4}|localhost(?=\/)|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(?::(\d*))?([\/]?[^\s\?]*[\/]{1})*(?:\/?([^\s\n\?\[\]\{\}\#]*(?:(?=\.)){1}|[^\s\n\?\[\]\{\}\.\#]*)?([\.]{1}[^\s\?\#]*)?)?(?:\?{1}([^\s\n\#\[\]]*))?([\#][^\s\n]*)?\)?",
-    re.IGNORECASE,
-)
-
 SLICE_REGEX = re.compile(r"(-?\d+)?(:?(-?\d+)?)?")
 
 
@@ -953,7 +948,7 @@ class Bot:
     def find_unique_urls(self, message):
         from pajbot.modules.linkchecker import find_unique_urls
 
-        return find_unique_urls(URL_REGEX, message)
+        return find_unique_urls(message)
 
 
 def _filter_time_since_dt(var, args):

--- a/pajbot/modules/basic/ab.py
+++ b/pajbot/modules/basic/ab.py
@@ -1,6 +1,5 @@
 import logging
 
-from pajbot.bot import URL_REGEX
 from pajbot.models.command import Command
 from pajbot.models.command import CommandExample
 from pajbot.modules import BaseModule
@@ -54,7 +53,7 @@ class AbCommandModule(BaseModule):
             return False
 
         # check if there is a link in the message
-        check_message = find_unique_urls(URL_REGEX, message)
+        check_message = find_unique_urls(message)
         if len(check_message) > 0:
             return False
 

--- a/pajbot/modules/linkchecker.py
+++ b/pajbot/modules/linkchecker.py
@@ -5,6 +5,7 @@ import urllib.parse
 import requests
 from bs4 import BeautifulSoup
 from sqlalchemy import Column, INT, TEXT
+from urlextract import URLExtract
 
 import pajbot.managers
 import pajbot.models
@@ -20,6 +21,10 @@ from pajbot.modules import BaseModule
 from pajbot.modules import ModuleSetting
 
 log = logging.getLogger(__name__)
+
+
+extractor = URLExtract()
+extractor.update_when_older(14)
 
 
 def is_subdomain(x, y):
@@ -61,11 +66,9 @@ def is_same_url(x, y):
     )
 
 
-def find_unique_urls(regex, message):
-    _urls = regex.finditer(message)
+def find_unique_urls(message):
     urls = []
-    for i in _urls:
-        url = i.group(0)
+    for url in extractor.gen_urls(message):
         if not (url.startswith("http://") or url.startswith("https://")):
             url = "http://" + url
         if not (url[-1].isalpha() or url[-1].isnumeric() or url[-1] == "/"):

--- a/pajbot/tests/test_url_parser.py
+++ b/pajbot/tests/test_url_parser.py
@@ -30,24 +30,30 @@ def test_is_same_url():
 
 def test_find_unique_urls():
     from pajbot.modules.linkchecker import find_unique_urls
-    from pajbot.bot import URL_REGEX
 
-    assert find_unique_urls(URL_REGEX, "pajlada.se test http://pajlada.se") == {"http://pajlada.se"}
-    assert find_unique_urls(URL_REGEX, "pajlada.se pajlada.com foobar.se") == {
+    assert find_unique_urls("pajlada.se test http://pajlada.se") == {"http://pajlada.se"}
+    assert find_unique_urls("pajlada.se pajlada.com foobar.se") == {
         "http://pajlada.se",
         "http://pajlada.com",
         "http://foobar.se",
     }
-    assert find_unique_urls(URL_REGEX, "foobar.com foobar.com") == {"http://foobar.com"}
-    assert find_unique_urls(URL_REGEX, "foobar.com foobar.se"), {"http://foobar.com" == "http://foobar.se"}
-    assert find_unique_urls(URL_REGEX, "www.foobar.com foobar.se"), {"http://www.foobar.com" == "http://foobar.se"}
+    assert find_unique_urls("foobar.com foobar.com") == {"http://foobar.com"}
+    assert find_unique_urls("foobar.com foobar.se"), {"http://foobar.com" == "http://foobar.se"}
+    assert find_unique_urls("www.foobar.com foobar.se"), {"http://www.foobar.com" == "http://foobar.se"}
 
     # TODO: Edge case, this behaviour should probably be changed. These URLs should be considered the same.
     # Use is_same_url method?
-    assert find_unique_urls(URL_REGEX, "pajlada.se/ pajlada.se"), {"http://pajlada.se/" == "http://pajlada.se"}
+    assert find_unique_urls("pajlada.se/ pajlada.se"), {"http://pajlada.se/" == "http://pajlada.se"}
 
     # TODO: The protocol of a URL is entirely thrown away, this behaviour should probably be changed.
-    assert find_unique_urls(URL_REGEX, "https://pajlada.se/ https://pajlada.se") == {
+    assert find_unique_urls("https://pajlada.se/ https://pajlada.se") == {
         "https://pajlada.se/",
         "https://pajlada.se",
     }
+
+    assert find_unique_urls("foo 192.168.0.1 bar") == {
+        "http://192.168.0.1",
+    }
+
+    assert find_unique_urls("omg this isn't chatting, this is meme-ing...my vanity") == set()
+    assert find_unique_urls("foo 1.40 bar") == set()

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ tweepy==3.10.0
 Twisted==20.3.0
 Unidecode==1.1.2
 uWSGI==2.0.19.1
+urlextract==1.2.0


### PR DESCRIPTION
The "indirection" in `pajbot/bot.py` is left on purpose for now, as the function exists in the modules package if we just imported it on top we would run into a circular dependency

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->

Fixes #722