### PR TITLE
Add an option to allow mods to change the game/title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Minor: Added an option to the `stream_update` module that allows moderators to change the title/game (without the level requirement).
+- Minor: Added an option to the `stream_update` module that allows moderators to change the title/game (without the level requirement). (#1165)
 - Minor: Added a new module to print a chat/whsiper alert on cheer. (#1158)
 
 ## v1.49

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
+- Minor: Added an option to the `stream_update` module that allows moderators to change the title/game (without the level requirement).
 - Minor: Added a new module to print a chat/whsiper alert on cheer. (#1158)
 
 ## v1.49

--- a/pajbot/modules/basic/stream_update.py
+++ b/pajbot/modules/basic/stream_update.py
@@ -23,6 +23,20 @@ class StreamUpdateModule(BaseModule):
     PARENT_MODULE = BasicCommandsModule
     SETTINGS = [
         ModuleSetting(
+            key="allow_mods_change_title",
+            label="Allow all moderators to change the title (ignores the level setting)",
+            type="boolean",
+            required=True,
+            default=False,
+        ),
+        ModuleSetting(
+            key="allow_mods_change_game",
+            label="Allow all moderators to change the game (ignores the level setting)",
+            type="boolean",
+            required=True,
+            default=False,
+        ),
+        ModuleSetting(
             key="setgame_trigger",
             label="Set game trigger (e.g. setgame)",
             type="text",
@@ -95,31 +109,63 @@ class StreamUpdateModule(BaseModule):
 
     def load_commands(self, **options):
         setgame_trigger = self.settings["setgame_trigger"].lower().replace("!", "").replace(" ", "")
-        self.commands[setgame_trigger] = Command.raw_command(
-            self.update_game,
-            level=self.settings["level"],
-            description="Update the stream's game",
-            examples=[
-                CommandExample(
-                    None,
-                    'Update the game to "World of Warcraft"',
-                    chat=f"user:!{setgame_trigger} World of Warcraft\n"
-                    'bot>user:pajlada updated the game to "World of Warcraft"',
-                ).parse()
-            ],
-        )
+        if self.settings["allow_mods_change_game"] is True:
+            self.commands[setgame_trigger] = Command.raw_command(
+                self.update_game,
+                level=100,
+                mod_only=True,
+                description="Update the stream's game",
+                examples=[
+                    CommandExample(
+                        None,
+                        'Update the game to "World of Warcraft"',
+                        chat=f"user:!{setgame_trigger} World of Warcraft\n"
+                        'bot>user:pajlada updated the game to "World of Warcraft"',
+                    ).parse()
+                ],
+            )
+        else:
+            self.commands[setgame_trigger] = Command.raw_command(
+                self.update_game,
+                level=self.settings["level"],
+                description="Update the stream's game",
+                examples=[
+                    CommandExample(
+                        None,
+                        'Update the game to "World of Warcraft"',
+                        chat=f"user:!{setgame_trigger} World of Warcraft\n"
+                        'bot>user:pajlada updated the game to "World of Warcraft"',
+                    ).parse()
+                ],
+            )
 
         settitle_trigger = self.settings["settitle_trigger"].lower().replace("!", "").replace(" ", "")
-        self.commands[settitle_trigger] = Command.raw_command(
-            self.update_title,
-            level=self.settings["level"],
-            description="Update the stream's title",
-            examples=[
-                CommandExample(
-                    None,
-                    'Update the title to "Games and shit"',
-                    chat=f"user:!{settitle_trigger} Games and shit\n"
-                    'bot>user:pajlada updated the title to "Games and shit"',
-                ).parse()
-            ],
-        )
+        if self.settings["allow_mods_change_title"] is True:
+            self.commands[settitle_trigger] = Command.raw_command(
+                self.update_title,
+                level=100,
+                mod_only=True,
+                description="Update the stream's title",
+                examples=[
+                    CommandExample(
+                        None,
+                        'Update the title to "Games and shit"',
+                        chat=f"user:!{settitle_trigger} Games and shit\n"
+                        'bot>user:pajlada updated the title to "Games and shit"',
+                    ).parse()
+                ],
+            )
+        else:
+            self.commands[settitle_trigger] = Command.raw_command(
+                self.update_title,
+                level=self.settings["level"],
+                description="Update the stream's title",
+                examples=[
+                    CommandExample(
+                        None,
+                        'Update the title to "Games and shit"',
+                        chat=f"user:!{settitle_trigger} Games and shit\n"
+                        'bot>user:pajlada updated the title to "Games and shit"',
+                    ).parse()
+                ],
+            )


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

This has been requested a couple of times by some people I host the bot for. Harmless addition, useful for those that don't want to manually change all their mods' level just to change the title/game.