### PR TITLE
Variable filter argument now allow the period character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Minor: Added the filter `ceil` which returns the smallest integer greater than or equal to the parameter. (#1168)
 - Minor: Added the filter `floor` which returns the largest integer less than or equal to the parameter. (#1168)
 - Minor: Added the variable `datetimefromisoformat` which allows commands to generate a full datetime object from a given string, which can then be further expanded on using filters. (#1169)
-- Minor: Filter arguments now allow the period character `.`
+- Minor: Filter arguments now allow the period character `.` (#1171)
 
 ## v1.49
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Minor: Added the filter `ceil` which returns the smallest integer greater than or equal to the parameter. (#1168)
 - Minor: Added the filter `floor` which returns the largest integer less than or equal to the parameter. (#1168)
 - Minor: Added the variable `datetimefromisoformat` which allows commands to generate a full datetime object from a given string, which can then be further expanded on using filters. (#1169)
+- Minor: Filter arguments now allow the period character `.`
 
 ## v1.49
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -44,7 +44,7 @@ Examples for valid substitutions: `$(user;1:points)` - get the user with the log
 #### Math
 
 `add` - tries to convert the variable result into a number, then adds it to the defined filter argument - e.g `$(kvi:active_subs|add(5))` would add 5 to the amount of active subs you have.  
-`subtract` - tries to convert the variable result into a number, then subtracts the filter argument from it - e.g. `$(kvi:active_subs|subtract(5))` would subtract 5 from the amount of subs you have.  
+`subtract` - tries to convert the variable result into a number, then subtracts the filter argument from it - e.g. `$(kvi:active_subs|subtract(5.3))` would subtract 5.3 from the amount of subs you have.  
 `multiply` - tries to convert the variable result into a number, then multiplies it by the filter argument - e.g. `$(kvi:active_subs|multiply(5))` would multiply the amount of subs you have by 5.  
 `divide` - tries to convert the variable result into a number, then divides it into the defined filter argument - e.g. `$(kvi:active_subs|divide(5))` would divide the amount of subs you have into 5.  
 `ceil` - returns the smallest integer greater than or equal to the variable result - e.g. `$(kvi:active_subs|divide(5)|ceil)` would divide the amount of subs you have into 5, and return the number rounded up to the nearest whole number.  

--- a/pajbot/models/action.py
+++ b/pajbot/models/action.py
@@ -124,7 +124,7 @@ class IfSubstitution:
 class Substitution:
     argument_substitution_regex = re.compile(r"\$\((\d+)\)")
     substitution_regex = re.compile(
-        r'\$\(([a-z_]+)(\;[0-9]+)?(\:[\w\.\/ -]+|\:\$\([\w_:;\._\/ -]+\))?(\|[\w]+(\([\w%:/ +-]+\))?)*(\,[\'"]{1}[\w \|$;_\-:()\.]+[\'"]{1}){0,2}\)'
+        r'\$\(([a-z_]+)(\;[0-9]+)?(\:[\w\.\/ -]+|\:\$\([\w_:;\._\/ -]+\))?(\|[\w]+(\([\w%:/ +-.]+\))?)*(\,[\'"]{1}[\w \|$;_\-:()\.]+[\'"]{1}){0,2}\)'
     )
     # https://stackoverflow.com/a/7109208
     urlfetch_substitution_regex = re.compile(r"\$\(urlfetch ([A-Za-z0-9\-._~:/?#\[\]@!$%&\'()*+,;=]+)\)")


### PR DESCRIPTION
This is useful for filters like `divide` where you might want to divide
    something by a non-whole number


Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
