### PR TITLE
Updated minimum required python version in docs

### DIFF
--- a/install-docs/README.md
+++ b/install-docs/README.md
@@ -43,7 +43,7 @@ sudo apt update
 sudo apt install python3 python3-dev python3-pip python3-venv
 ```
 
-Now, double-check that you have Python 3.6 or newer installed:
+Now, double-check that you have Python 3.7 or newer installed:
 
 ```bash
 python3 --version


### PR DESCRIPTION


Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

Turns out, that autobahn 21.3.1 is a part of python 3.7, so I updated documentation since we no longer support python 3.6.
