### PR TITLE
Revert "Bump flask from 1.1.2 to 2.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ autobahn==21.3.1
 beautifulsoup4==4.9.3
 colorama==0.4.4
 cssmin==0.2.0
-Flask==2.0.0
+Flask==1.1.2
 Flask-Assets==2.0
 Flask-RESTful==0.3.8
 Flask-Scrypt==0.1.3.6


### PR DESCRIPTION
Reverts pajbot/pajbot#1243

Refer issues + other solutions if the necessary prs don't get merged:
https://github.com/pallets/flask/issues/4009
https://github.com/flask-restful/flask-restful/pull/914
https://github.com/flask-restful/flask-restful/issues/883