### PR TITLE
Made Twitter (un)follow buttons work again after CSRF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
+- Bugfix: Twitter (un)follow buttons in admin zone work again. (#1250)
+
 ## v1.52
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!

--- a/templates/admin/home.html
+++ b/templates/admin/home.html
@@ -38,7 +38,11 @@ function on_success(response, key)
                 },
                 onSuccess: function(response, element, xhr) {
                     element.closest('tr').hide();
-                }
+                },
+                beforeXHR: function(xhr) {
+                    xhr.setRequestHeader('X-CSRFToken', csrf_token);
+                    return xhr;
+                },
             });
             $action_td.append($unfollow_btn);
 {% endif -%}
@@ -63,7 +67,11 @@ $(document).ready(function() {
             console.log(response);
             $('.twitter-follow input[type="text"]').val('');
             paginate_reload('.twitter_follows');
-        }
+        },
+        beforeXHR: function(xhr) {
+            xhr.setRequestHeader("X-CSRFToken", csrf_token);
+            return xhr;
+        },
     });
 });
 </script>


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

After #1248 was merged in, Twitter follow and unfollow buttons on frontend broke and `/api/v1/twitter/follow` returned 400 because of no CSRF token provided. This simple fix adds missing header.
Unsure about changelog entry since there was a stable release made already.
