### PR TITLE
Fix/usernotice events being processed by chat alert modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Minor: Migrate from Kraken to Helix for global emote fetching. (#1289)
 - Minor: Migrate from `twitchemotes.com` to Helix for channel emote fetching. (#1290)
 - Minor: Added `mod_only` & `run_through_banphrases` fields to edit command page. (#1293)
+- Bugfix: Stop `USERNOTICE` events occurring in a bot hub from being processed.
 - Bugfix: Fixed issue where bot would take points and attempt to untimeout/unban a user that isn't timed out or banned in the paidtimeout module. (#1308)
 - Bugfix: Fixed issue where level 2000 users couldn't bypass the cooldown of the playsounds module. (#1292)
 - Bugfix: Users can no longer bypass long massping timeouts by also typing a banphrase in their message. (#1117, #1209, #1253)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Minor: Migrate from Kraken to Helix for global emote fetching. (#1289)
 - Minor: Migrate from `twitchemotes.com` to Helix for channel emote fetching. (#1290)
 - Minor: Added `mod_only` & `run_through_banphrases` fields to edit command page. (#1293)
-- Bugfix: Stop `USERNOTICE` events occurring in a bot hub from being processed.
+- Bugfix: Stop `USERNOTICE` events occurring in a bot hub from being processed. (#1314)
 - Bugfix: Fixed issue where bot would take points and attempt to untimeout/unban a user that isn't timed out or banned in the paidtimeout module. (#1308)
 - Bugfix: Fixed issue where level 2000 users couldn't bypass the cooldown of the playsounds module. (#1292)
 - Bugfix: Users can no longer bypass long massping timeouts by also typing a banphrase in their message. (#1117, #1209, #1253)

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -788,6 +788,9 @@ class Bot:
     def on_usernotice(self, chatconn, event):
         tags = {tag["key"]: tag["value"] if tag["value"] is not None else "" for tag in event.tags}
 
+        if event.target != self.channel:
+            return
+
         id = tags["user-id"]
         login = tags["login"]
         name = tags["display-name"]


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] Changes tested and confirmed working

Fairly self explanatory bug. You can see in the first screenshot that no raid was received, rather it was me raiding my hub channel. This pr fixes that issue:

![image](https://user-images.githubusercontent.com/12804673/123269302-334a5780-d542-11eb-98bf-bc7e680e3692.png)