### PR TITLE
Turn off `extendsub` and `giftsubupgrade` whispering by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
 - Major: Added support for 7tv.app emotes (#1256, #1260, #1261, #1317)
-- Minor: Added support for the `extendsub` msg-id to the `subalert` module.
-- Minor: Added support for the `giftpaidupgrade` msg-id to the `subalert` module. (#1306, #1315)
+- Minor: Added support for the `extendsub` msg-id to the `subalert` module. (#1311, #1318)
+- Minor: Added support for the `giftpaidupgrade` msg-id to the `subalert` module. (#1306, #1315, #1318)
 - Minor: Migrate from Kraken to Helix for global emote fetching. (#1289)
 - Minor: Migrate from `twitchemotes.com` to Helix for channel emote fetching. (#1290)
 - Minor: Added `mod_only` & `run_through_banphrases` fields to edit command page. (#1293)

--- a/pajbot/modules/chat_alerts/subalert.py
+++ b/pajbot/modules/chat_alerts/subalert.py
@@ -146,7 +146,7 @@ class SubAlertModule(BaseModule):
             type="text",
             required=True,
             placeholder="Thank you for upgrading your gift sub {username}! PogChamp <3",
-            default="Thank you for upgrading your gift sub {username}! PogChamp <3",
+            default="",
         ),
         ModuleSetting(
             key="extend_sub_whisper",
@@ -154,7 +154,7 @@ class SubAlertModule(BaseModule):
             type="text",
             required=True,
             placeholder="Thank you for extending your sub {username}! PogChamp",
-            default="Thank you for extending your sub {username}! PogChamp",
+            default="",
             constraints={"max_str_len": 400},
         ),
         ModuleSetting(


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

Whispering isn't enabled by default for new sub notifications, this should be the same.