### PR TITLE
Changed the timeout length limit for the Repetitive Spam module from [5s,10m] to [1s,2w] and increased the unique words and message repetitions limits to 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Minor: Changed the timeout length limit for the Repetitive Spam module from [5s,10m] to [1s,2w]. (#) 
+- Minor: Changed the timeout length limit for the Repetitive Spam module from [5s,10m] to [1s,2w]. (#1339) 
 - Minor: Increased the Repetitive Spam module unique words and message repetitions limits to 100. (#) 
 - Bugfix: Corrected wrong usage examples for editing command aliases. (#1325)
 - Bugfix: Users with level > 2000 are now also shown as admins on the web moderators page. (#1324, #1326)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Minor: Changed the timeout length limit for the Repetitive Spam module from [5s,10m] to [1s,2w]. (#1339) 
+- Minor: Changed the timeout length limit for the Repetitive Spam module from [5s,10m] to [1s,2w]. (#1339)
 - Minor: Increased the Repetitive Spam module unique words and message repetitions limits to 100. (#1339) 
 - Bugfix: Corrected wrong usage examples for editing command aliases. (#1325)
 - Bugfix: Users with level > 2000 are now also shown as admins on the web moderators page. (#1324, #1326)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
 - Minor: Changed the timeout length limit for the Repetitive Spam module from [5s,10m] to [1s,2w]. (#1339)
-- Minor: Increased the Repetitive Spam module unique words and message repetitions limits to 100. (#1339) 
+- Minor: Increased the Repetitive Spam module unique words and message repetitions limits to 100. (#1339)
 - Bugfix: Corrected wrong usage examples for editing command aliases. (#1325)
 - Bugfix: Users with level > 2000 are now also shown as admins on the web moderators page. (#1324, #1326)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
+- Minor: Changed the timeout length limit for the Repetitive Spam module from [5s,10m] to [1s,2w]. (#) 
+- Minor: Increased the Repetitive Spam module unique words and message repetitions limits to 100. (#) 
 - Bugfix: Corrected wrong usage examples for editing command aliases. (#1325)
 - Bugfix: Users with level > 2000 are now also shown as admins on the web moderators page. (#1324, #1326)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
 - Minor: Changed the timeout length limit for the Repetitive Spam module from [5s,10m] to [1s,2w]. (#1339) 
-- Minor: Increased the Repetitive Spam module unique words and message repetitions limits to 100. (#) 
+- Minor: Increased the Repetitive Spam module unique words and message repetitions limits to 100. (#1339) 
 - Bugfix: Corrected wrong usage examples for editing command aliases. (#1325)
 - Bugfix: Users with level > 2000 are now also shown as admins on the web moderators page. (#1324, #1326)
 

--- a/pajbot/modules/repspam.py
+++ b/pajbot/modules/repspam.py
@@ -49,7 +49,7 @@ class RepspamModule(BaseModule):
             required=True,
             placeholder="",
             default=3,
-            constraints={"min_value": 1, "max_value": 10},
+            constraints={"min_value": 1, "max_value": 100},
         ),
         ModuleSetting(
             key="max_spam_repetitions",
@@ -58,7 +58,7 @@ class RepspamModule(BaseModule):
             required=True,
             placeholder="",
             default=4,
-            constraints={"min_value": 1, "max_value": 20},
+            constraints={"min_value": 1, "max_value": 100},
         ),
         ModuleSetting(
             key="min_unique_words_in_spam",
@@ -76,7 +76,7 @@ class RepspamModule(BaseModule):
             required=True,
             placeholder="Timeout length in seconds",
             default=10,
-            constraints={"min_value": 5, "max_value": 600},
+            constraints={"min_value": 1, "max_value": 1209600},
         ),
         ModuleSetting(
             key="timeout_reason",


### PR DESCRIPTION

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
