### PR TITLE
Changed the timeout length limits for the Emote Timeout module from [3s,2m] to [1s,2w]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Minor: Changed the timeout length limits for the Emote Timeout module from [3s,2m] to [1s,2w]. (#1355) 
+- Minor: Changed the timeout length limits for the Emote Timeout module from [3s,2m] to [1s,2w]. (#1349) 
 - Bugfix: Corrected wrong usage examples for editing command aliases. (#1325)
 - Bugfix: Users with level > 2000 are now also shown as admins on the web moderators page. (#1324, #1326)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Minor: Changed the timeout length limits for the Emote Timeout module from [3s,2m] to [1s,2w]. (#) 
+- Minor: Changed the timeout length limits for the Emote Timeout module from [3s,2m] to [1s,2w]. (#1355) 
 - Bugfix: Corrected wrong usage examples for editing command aliases. (#1325)
 - Bugfix: Users with level > 2000 are now also shown as admins on the web moderators page. (#1324, #1326)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
+- Minor: Changed timeout limits for the Emote Timeout module from [3s,2m] to [1s,2w]. (#) 
 - Bugfix: Corrected wrong usage examples for editing command aliases. (#1325)
 - Bugfix: Users with level > 2000 are now also shown as admins on the web moderators page. (#1324, #1326)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Minor: Changed the timeout length limits for the Emote Timeout module from [3s,2m] to [1s,2w]. (#1349) 
+- Minor: Changed the timeout length limits for the Emote Timeout module from [3s,2m] to [1s,2w]. (#1349)
 - Bugfix: Corrected wrong usage examples for editing command aliases. (#1325)
 - Bugfix: Users with level > 2000 are now also shown as admins on the web moderators page. (#1324, #1326)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Minor: Changed timeout limits for the Emote Timeout module from [3s,2m] to [1s,2w]. (#) 
+- Minor: Changed the timeout length limits for the Emote Timeout module from [3s,2m] to [1s,2w]. (#) 
 - Bugfix: Corrected wrong usage examples for editing command aliases. (#1325)
 - Bugfix: Users with level > 2000 are now also shown as admins on the web moderators page. (#1324, #1326)
 

--- a/pajbot/modules/emote_timeout.py
+++ b/pajbot/modules/emote_timeout.py
@@ -49,7 +49,7 @@ class EmoteTimeoutModule(BaseModule):
             required=True,
             placeholder="",
             default=5,
-            constraints={"min_value": 3, "max_value": 120},
+            constraints={"min_value": 1, "max_value": 1209600},
         ),
         ModuleSetting(
             key="enable_in_online_chat", label="Enabled in online chat", type="boolean", required=True, default=True


### PR DESCRIPTION

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
