### PR TITLE
Changed the timeout length limits for the Maximum Message Length module from [30s,1hr] to [1s,2w]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
+- Minor: Changed the timeout length limits for the Maximum Message Length module from [30s,1hr] to [1s,2w]. (#) 
 - Bugfix: Corrected wrong usage examples for editing command aliases. (#1325)
 - Bugfix: Users with level > 2000 are now also shown as admins on the web moderators page. (#1324, #1326)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Minor: Changed the timeout length limits for the Maximum Message Length module from [30s,1hr] to [1s,2w]. (#1352) 
+- Minor: Changed the timeout length limits for the Maximum Message Length module from [30s,1hr] to [1s,2w]. (#1352)
 - Bugfix: Corrected wrong usage examples for editing command aliases. (#1325)
 - Bugfix: Users with level > 2000 are now also shown as admins on the web moderators page. (#1324, #1326)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Minor: Changed the timeout length limits for the Maximum Message Length module from [30s,1hr] to [1s,2w]. (#) 
+- Minor: Changed the timeout length limits for the Maximum Message Length module from [30s,1hr] to [1s,2w]. (#1352) 
 - Bugfix: Corrected wrong usage examples for editing command aliases. (#1325)
 - Bugfix: Users with level > 2000 are now also shown as admins on the web moderators page. (#1324, #1326)
 

--- a/pajbot/modules/maxmsglength.py
+++ b/pajbot/modules/maxmsglength.py
@@ -23,7 +23,7 @@ class MaxMsgLengthModule(BaseModule):
             required=True,
             placeholder="",
             default=400,
-            constraints={"min_value": 40, "max_value": 1000},
+            constraints={"min_value": 1, "max_value": 500},
         ),
         ModuleSetting(
             key="max_msg_length_offline",
@@ -32,7 +32,7 @@ class MaxMsgLengthModule(BaseModule):
             required=True,
             placeholder="",
             default=400,
-            constraints={"min_value": 40, "max_value": 1000},
+            constraints={"min_value": 1, "max_value": 500},
         ),
         ModuleSetting(
             key="timeout_length",
@@ -41,7 +41,7 @@ class MaxMsgLengthModule(BaseModule):
             required=True,
             placeholder="Timeout length in seconds",
             default=120,
-            constraints={"min_value": 30, "max_value": 3600},
+            constraints={"min_value": 1, "max_value": 1209600},
         ),
         ModuleSetting(
             key="bypass_level",


### PR DESCRIPTION

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
