### PR TITLE
Changed the timeout length limits for the Action Command Moderation module from [30s,1hr] to [1s,2w]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
+- Minor: Changed timeout limits for Action Command Moderation module from [30s,1hr] to [1s,2w]. (#) 
 - Bugfix: Corrected wrong usage examples for editing command aliases. (#1325)
 - Bugfix: Users with level > 2000 are now also shown as admins on the web moderators page. (#1324, #1326)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Minor: Changed the timeout length limits for the Action Command Moderation module from [30s,1hr] to [1s,2w]. (#) 
+- Minor: Changed the timeout length limits for the Action Command Moderation module from [30s,1hr] to [1s,2w]. (#1333) 
 - Bugfix: Corrected wrong usage examples for editing command aliases. (#1325)
 - Bugfix: Users with level > 2000 are now also shown as admins on the web moderators page. (#1324, #1326)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Minor: Changed the timeout length limits for the Action Command Moderation module from [30s,1hr] to [1s,2w]. (#1354) 
+- Minor: Changed the timeout length limits for the Action Command Moderation module from [30s,1hr] to [1s,2w]. (#1354)
 - Bugfix: Corrected wrong usage examples for editing command aliases. (#1325)
 - Bugfix: Users with level > 2000 are now also shown as admins on the web moderators page. (#1324, #1326)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Minor: Changed timeout limits for Action Command Moderation module from [30s,1hr] to [1s,2w]. (#) 
+- Minor: Changed the timeout length limits for the Action Command Moderation module from [30s,1hr] to [1s,2w]. (#) 
 - Bugfix: Corrected wrong usage examples for editing command aliases. (#1325)
 - Bugfix: Users with level > 2000 are now also shown as admins on the web moderators page. (#1324, #1326)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Minor: Changed the timeout length limits for the Action Command Moderation module from [30s,1hr] to [1s,2w]. (#1333) 
+- Minor: Changed the timeout length limits for the Action Command Moderation module from [30s,1hr] to [1s,2w]. (#1354) 
 - Bugfix: Corrected wrong usage examples for editing command aliases. (#1325)
 - Bugfix: Users with level > 2000 are now also shown as admins on the web moderators page. (#1324, #1326)
 

--- a/pajbot/modules/actionchecker.py
+++ b/pajbot/modules/actionchecker.py
@@ -68,7 +68,7 @@ class ActionCheckerModule(BaseModule):
             required=True,
             placeholder="Timeout length in seconds",
             default=30,
-            constraints={"min_value": 30, "max_value": 3600},
+            constraints={"min_value": 1, "max_value": 1209600},
         ),
         ModuleSetting(
             key="bypass_level",


### PR DESCRIPTION

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
