### PR TITLE
Fix pyramid module not handling double spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Minor: Increased the maximum point/token limits for the Show Emote sub-module to 1000000. (#1334)
 - Bugfix: Corrected wrong usage examples for editing command aliases. (#1325)
 - Bugfix: Users with level > 2000 are now also shown as admins on the web moderators page. (#1324, #1326)
+- Bugfix: Pyramid parser did not handle double spaces in messages correctly. (#1374)
 
 ## v1.53
 

--- a/pajbot/modules/pyramid.py
+++ b/pajbot/modules/pyramid.py
@@ -75,7 +75,9 @@ class PyramidModule(BaseModule):
         message = unidecode(message).strip()
 
         try:
-            msg_parts = message.split(" ")
+            # Filter out any empty parts
+            # This makes sure "foo  bar" returns ["foo", "bar"] instead of ["foo", "", "bar"]
+            msg_parts = [part for part in message.split(" ") if part]
             if len(self.data) > 0:
                 cur_len = len(msg_parts)
                 last_len = len(self.data[-1])


### PR DESCRIPTION
If a user posts a pyramid in chat that looks like this, the pyramid parser will work
```
user: Kappa
user: Kappa Kappa
user: Kappa Kappa Kappa
user: Kappa Kappa
user: Kappa
```

If a user posts a pyramid in chat that looks like this, the pyramid parser would not work before, but will work now
```
user: Kappa
user: Kappa  Kappa
user: Kappa Kappa Kappa
user: Kappa Kappa
user: Kappa
```

I confirmed this works by running one dev pajbot and one old pajbot in my chat
![image](https://user-images.githubusercontent.com/962989/127770255-4fe25fe4-0282-4bc1-ac12-235b465bc188.png)

The upper pyramid contains stray spaces, the bottom pyramid does not.

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
