### PR TITLE
Added playsound admin logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Minor: Added playsound admin panel logging. (#1382)
+- Minor: Added playsound admin panel logging. (#1381, #1382)
 - Minor: Added optional warning support to the actionchecker module. (#1362)
 - Minor: Added optional warning support to the casechecker module. (#1365)
 - Minor: Added optional warning support to the emote_limit module. (#1366)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
+- Minor: Added playsound admin panel logging. (#1382)
 - Minor: Added optional warning support to the actionchecker module. (#1362)
 - Minor: Added optional warning support to the casechecker module. (#1365)
 - Minor: Added optional warning support to the emote_limit module. (#1366)

--- a/pajbot/modules/playsound.py
+++ b/pajbot/modules/playsound.py
@@ -8,6 +8,7 @@ from pajbot.models.playsound import Playsound
 from pajbot.modules import BaseModule
 from pajbot.modules import ModuleSetting
 from pajbot.models.command import Command
+from pajbot.managers.adminlog import AdminLogManager
 
 log = logging.getLogger(__name__)
 
@@ -362,6 +363,8 @@ class PlaysoundModule(BaseModule):
 
             session.add(playsound)
             bot.whisper(source, "Successfully added your playsound.")
+            log_msg = f'The {name} playsound has been added'
+            AdminLogManager.add_entry("Playsound added", source, log_msg)
 
     def edit_playsound_command(self, bot, source, message, **rest):
         """Method for editing playsounds.
@@ -392,6 +395,8 @@ class PlaysoundModule(BaseModule):
                 )
                 return
 
+            old_link = playsound.link
+
             if not self.update_link(bot, source, playsound, link):
                 return
 
@@ -404,8 +409,14 @@ class PlaysoundModule(BaseModule):
             if not self.update_enabled(bot, source, playsound, options):
                 return
 
+            if link in message:
+                log_msg = f'The {name} playsound has been updated from {old_link} to {link}'
+            else:
+                log_msg = f'The {name} playsound has been updated'
+
             session.add(playsound)
             bot.whisper(source, "Successfully edited your playsound.")
+            AdminLogManager.add_entry("Playsound edited", source, log_msg)
 
     @staticmethod
     def remove_playsound_command(bot, source, message, **rest):
@@ -427,6 +438,8 @@ class PlaysoundModule(BaseModule):
 
             session.delete(playsound)
             bot.whisper(source, "Successfully deleted your playsound.")
+            log_msg = f'The {playsound_name} playsound has been removed'
+            AdminLogManager.add_entry("Playsound removed", source, log_msg)
 
     @staticmethod
     def debug_playsound_command(bot, source, message, **rest):

--- a/pajbot/modules/playsound.py
+++ b/pajbot/modules/playsound.py
@@ -363,7 +363,7 @@ class PlaysoundModule(BaseModule):
 
             session.add(playsound)
             bot.whisper(source, "Successfully added your playsound.")
-            log_msg = f'The {name} playsound has been added'
+            log_msg = f"The {name} playsound has been added"
             AdminLogManager.add_entry("Playsound added", source, log_msg)
 
     def edit_playsound_command(self, bot, source, message, **rest):
@@ -410,9 +410,9 @@ class PlaysoundModule(BaseModule):
                 return
 
             if link in message:
-                log_msg = f'The {name} playsound has been updated from {old_link} to {link}'
+                log_msg = f"The {name} playsound has been updated from {old_link} to {link}"
             else:
-                log_msg = f'The {name} playsound has been updated'
+                log_msg = f"The {name} playsound has been updated"
 
             session.add(playsound)
             bot.whisper(source, "Successfully edited your playsound.")
@@ -438,7 +438,7 @@ class PlaysoundModule(BaseModule):
 
             session.delete(playsound)
             bot.whisper(source, "Successfully deleted your playsound.")
-            log_msg = f'The {playsound_name} playsound has been removed'
+            log_msg = f"The {playsound_name} playsound has been removed"
             AdminLogManager.add_entry("Playsound removed", source, log_msg)
 
     @staticmethod

--- a/pajbot/modules/playsound.py
+++ b/pajbot/modules/playsound.py
@@ -410,7 +410,7 @@ class PlaysoundModule(BaseModule):
     @staticmethod
     def remove_playsound_command(bot, source, message, **rest):
         """Method for removing playsounds.
-        Usage: !edit playsound PLAYSOUNDNAME
+        Usage: !remove playsound PLAYSOUNDNAME
         """
         playsound_name = PlaysoundModule.massage_name(message.split(" ")[0])
         # check for empty string


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

Implements basic logging into the playsound module. Simple things like: adding playsound, editing playsound (without/with link) and removing playsound. I decided not to complicate it too much and risk flooding logs by someone adjusting the volume/cooldown, etc.

Fixes #1381