### PR TITLE
Fix pyramid parsing bug introduced in a previous PR + allow emojis in pyramids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Minor: Increased the maximum point/token limits for the Show Emote sub-module to 1000000. (#1334)
 - Bugfix: Corrected wrong usage examples for editing command aliases. (#1325)
 - Bugfix: Users with level > 2000 are now also shown as admins on the web moderators page. (#1324, #1326)
-- Bugfix: Pyramid parser did not handle double spaces in messages correctly. (#1374)
+- Bugfix: Pyramid parser did not handle double spaces in messages correctly. (#1374, #1384)
 
 ## v1.53
 

--- a/pajbot/modules/pyramid.py
+++ b/pajbot/modules/pyramid.py
@@ -149,7 +149,7 @@ class PyramidModule(BaseModule):
         except:
             # Let's just catch all exceptions, in case I fucked up in the above spaghetti code
             log.exception(
-                "Unhandled exception in pyramid parser. Message={message}, self.data={self.data}, msg_parts={msg_parts}"
+                f"Unhandled exception in pyramid parser. Message={message}, self.data={self.data}, msg_parts={msg_parts}"
             )
 
     def enable(self, bot):

--- a/pajbot/modules/pyramid.py
+++ b/pajbot/modules/pyramid.py
@@ -79,61 +79,78 @@ class PyramidModule(BaseModule):
             # This makes sure "foo  bar" returns ["foo", "bar"] instead of ["foo", "", "bar"]
             msg_parts = [part for part in message.split(" ") if part]
             if len(self.data) > 0:
+                # A pyramid has been started before this message
                 cur_len = len(msg_parts)
-                last_len = len(self.data[-1])
-                pyramid_thing = self.data[-1][0]
-                len_diff = cur_len - last_len
-                if abs(len_diff) == 1:
-                    good = True
+                if cur_len > 0:
+                    last_len = len(self.data[-1])
+                    pyramid_thing = self.data[-1][0]
+                    len_diff = cur_len - last_len
+                    if abs(len_diff) == 1:
+                        good = True
 
-                    # Make sure the pyramid consists of the same item over and over again
-                    for x in msg_parts:
-                        if not x == pyramid_thing:
-                            good = False
-                            break
+                        # Make sure the pyramid consists of the same item over and over again
+                        for x in msg_parts:
+                            if not x == pyramid_thing:
+                                good = False
+                                break
 
-                    if good:
-                        self.data.append(msg_parts)
-                        if len_diff > 0:
-                            if self.going_down:
-                                self.data = []
-                                self.going_down = False
-                        elif len_diff < 0:
-                            self.going_down = True
-                            if cur_len == 1:
-                                # A pyramid was finished
-                                peak_length = 0
-                                for x in self.data:
-                                    if len(x) > peak_length:
-                                        peak_length = len(x)
+                        if good:
+                            self.data.append(msg_parts)
+                            if len_diff > 0:
+                                if self.going_down:
+                                    self.data = []
+                                    self.going_down = False
+                            elif len_diff < 0:
+                                self.going_down = True
+                                if cur_len == 1:
+                                    # A pyramid was finished
+                                    peak_length = 0
+                                    for x in self.data:
+                                        if len(x) > peak_length:
+                                            peak_length = len(x)
 
-                                arguments = {"emote": pyramid_thing, "user": source.name, "width": peak_length}
+                                    arguments = {"emote": pyramid_thing, "user": source.name, "width": peak_length}
 
-                                if peak_length > 2:
-                                    if peak_length < 5:
-                                        self.bot.say(self.get_phrase("message_5", **arguments))
-                                    elif peak_length < 7:
-                                        self.bot.say(self.get_phrase("message_7", **arguments))
-                                    elif peak_length < 15:
-                                        self.bot.say(self.get_phrase("message_15", **arguments))
-                                    elif peak_length < 25:
-                                        self.bot.say(self.get_phrase("message_25", **arguments))
-                                    else:
-                                        self.bot.say(self.get_phrase("message_else", **arguments))
-                                self.data = []
-                                self.going_down = False
+                                    if peak_length > 2:
+                                        if peak_length < 5:
+                                            self.bot.say(self.get_phrase("message_5", **arguments))
+                                        elif peak_length < 7:
+                                            self.bot.say(self.get_phrase("message_7", **arguments))
+                                        elif peak_length < 15:
+                                            self.bot.say(self.get_phrase("message_15", **arguments))
+                                        elif peak_length < 25:
+                                            self.bot.say(self.get_phrase("message_25", **arguments))
+                                        else:
+                                            self.bot.say(self.get_phrase("message_else", **arguments))
+                                    self.data = []
+                                    self.going_down = False
+                        else:
+                            # Breaking pyramid because not all parts of the message matches the
+                            # `pyramid_thing` value (i.e. the building block of the pyramid, like Kappa or KKona)
+                            self.data = []
+                            self.going_down = False
                     else:
+                        # Breaking pyramid because this message contained too many or too few parts
+                        # e.g. if the pyramid was in the following state:
+                        #   Kappa
+                        #   Kappa Kappa
+                        # and this message was "Kappa Kappa Kappa Kappa" or "Hi there hello there"
+                        # then we know there'd be a gap in the pyramid, so we don't do any block comparisons
                         self.data = []
                         self.going_down = False
                 else:
+                    # Break pyramid because the current message is empty
                     self.data = []
                     self.going_down = False
 
-            if len(msg_parts) == 1 and len(self.data) == 0:
+            if len(msg_parts) == 1 and len(self.data) == 0 and len(msg_parts[0]):
+                # Start pyramid using msg_parts
                 self.data.append(msg_parts)
         except:
             # Let's just catch all exceptions, in case I fucked up in the above spaghetti code
-            log.exception("Unhandled exception in pyramid parser")
+            log.exception(
+                "Unhandled exception in pyramid parser. Message={message}, self.data={self.data}, msg_parts={msg_parts}"
+            )
 
     def enable(self, bot):
         HandlerManager.add_handler("on_pubmsg", self.on_pubmsg)

--- a/pajbot/modules/pyramid.py
+++ b/pajbot/modules/pyramid.py
@@ -1,8 +1,6 @@
 import logging
 import re
 
-from unidecode import unidecode
-
 from pajbot.managers.handler import HandlerManager
 from pajbot.modules import BaseModule
 from pajbot.modules import ModuleSetting
@@ -64,6 +62,8 @@ class PyramidModule(BaseModule):
         ),
     ]
 
+    CHATTERINO_CHARACTER = "\U000e0000"
+
     def __init__(self, bot):
         super().__init__(bot)
         self.data = []
@@ -72,7 +72,7 @@ class PyramidModule(BaseModule):
 
     def on_pubmsg(self, source, message, **rest):
         # remove the invisible Chatterino suffix
-        message = unidecode(message).strip()
+        message = message.strip(PyramidModule.CHATTERINO_CHARACTER)
 
         try:
             # Filter out any empty parts


### PR DESCRIPTION
- Fix an issue that could occurr with the pyramid parser in case the user posted, what seemed to us, like an empty message
- Instead of using unidecode to strip out the chatterino character, just strip on the character itself.



Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
