### PR TITLE
Fix incorrect grammar on bot homepage

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -6,6 +6,7 @@
 {% set streamer_name = streamer.full_name' %}
 {% else %}
 {% set streamer_name = streamer.full_name's%}
+{% endif %}
 <h4>
     This is the website for <strong>{{ bot.name }}</strong> that moderates <a href="http://twitch.tv/{{ streamer.full_name }}">{{ streamer_name }}</a> channel.
 </h4>

--- a/templates/home.html
+++ b/templates/home.html
@@ -3,9 +3,9 @@
 {% block title %}Home{% endblock %}
 {% block body %}
 {% if streamer.full_name.endswith('s') %}
-{% set streamer_name = streamer.full_name' %}
+{% set streamer_name = streamer.full_name + "'" %}
 {% else %}
-{% set streamer_name = streamer.full_name's%}
+{% set streamer_name = streamer.full_name + "'s" %}
 {% endif %}
 <h4>
     This is the website for <strong>{{ bot.name }}</strong> that moderates <a href="http://twitch.tv/{{ streamer.full_name }}">{{ streamer_name }}</a> channel.

--- a/templates/home.html
+++ b/templates/home.html
@@ -3,9 +3,9 @@
 {% block title %}Home{% endblock %}
 {% block body %}
 {% if streamer.full_name.endswith('s') %}
-{% set streamer_name = streamer.full_name + "'" %}
+{% set streamer_name = streamer.name + "'" %}
 {% else %}
-{% set streamer_name = streamer.full_name + "'s" %}
+{% set streamer_name = streamer.name + "'s" %}
 {% endif %}
 <h4>
     This is the website for <strong>{{ bot.name }}</strong> that moderates <a href="http://twitch.tv/{{ streamer.full_name }}">{{ streamer_name }}</a> channel.

--- a/templates/home.html
+++ b/templates/home.html
@@ -2,8 +2,12 @@
 {% set active_page = 'home' %}
 {% block title %}Home{% endblock %}
 {% block body %}
+{% if streamer.full_name.endswith('s') %}
+{% set streamer_name = streamer.full_name' %}
+{% else %}
+{% set streamer_name = streamer.full_name's%}
 <h4>
-    This is the website for <strong>{{ bot.name }}</strong> that moderates <a href="http://twitch.tv/{{ streamer.full_name }}">{{ streamer.name }}'s</a> channel.
+    This is the website for <strong>{{ bot.name }}</strong> that moderates <a href="http://twitch.tv/{{ streamer.full_name }}">{{ streamer_name }}</a> channel.
 </h4>
 {% if stream_data['online'] == 'True' %}
 <h4>The stream is currently <strong><a href="http://twitch.tv/{{ streamer.full_name }}">LIVE</a></strong> with <strong>{{ stream_data['viewers']}}</strong> viewers ({{ stream_data['game'] }}).</h4>

--- a/templates/home.html
+++ b/templates/home.html
@@ -2,13 +2,8 @@
 {% set active_page = 'home' %}
 {% block title %}Home{% endblock %}
 {% block body %}
-{% if streamer.full_name.endswith('s') %}
-{% set streamer_name = streamer.name + "'" %}
-{% else %}
-{% set streamer_name = streamer.name + "'s" %}
-{% endif %}
 <h4>
-    This is the website for <strong>{{ bot.name }}</strong> that moderates <a href="http://twitch.tv/{{ streamer.full_name }}">{{ streamer_name }}</a> channel.
+    This is the website for <strong>{{ bot.name }}</strong> that moderates <a href="http://twitch.tv/{{ streamer.full_name }}">{{ streamer.name }}'{{% "" if streamer.name.endswith('s') else "s" %}}</a> channel.
 </h4>
 {% if stream_data['online'] == 'True' %}
 <h4>The stream is currently <strong><a href="http://twitch.tv/{{ streamer.full_name }}">LIVE</a></strong> with <strong>{{ stream_data['viewers']}}</strong> viewers ({{ stream_data['game'] }}).</h4>

--- a/templates/home.html
+++ b/templates/home.html
@@ -3,7 +3,7 @@
 {% block title %}Home{% endblock %}
 {% block body %}
 <h4>
-    This is the website for <strong>{{ bot.name }}</strong> that moderates <a href="http://twitch.tv/{{ streamer.full_name }}">{{ streamer.name }}'{{% "" if streamer.name.endswith('s') else "s" %}}</a> channel.
+    This is the website for <strong>{{ bot.name }}</strong> that moderates <a href="http://twitch.tv/{{ streamer.full_name }}">{{ streamer.name }}'{{% "" if lower(streamer.name).endswith('s') else "s" %}}</a> channel.
 </h4>
 {% if stream_data['online'] == 'True' %}
 <h4>The stream is currently <strong><a href="http://twitch.tv/{{ streamer.full_name }}">LIVE</a></strong> with <strong>{{ stream_data['viewers']}}</strong> viewers ({{ stream_data['game'] }}).</h4>


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

Proper English has it that:

A word ending in s that requires an apostrophe - most commonly due to ownership, should end with the apostrophe as opposed to `'s`. This addresses that issue. Refer below:

After changes:
![image](https://user-images.githubusercontent.com/12804673/130606298-b03d3ac1-7690-403e-a554-4e0923814511.png)

Before changes:
![image](https://user-images.githubusercontent.com/12804673/130606465-5f52f85d-822d-4d14-8cbe-c85523cb6399.png)

Note that `streamer.name` is the correct capitalization, whereas `streamer.full_name` is in lowercase. I've used `streamer.full_name` in order to check for the trailing s and printed with `streamer.name` as the final result.