### PR TITLE
Update rate limits according to new Twitch documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 
 - Bugfix: CLR overlay scrollbar is now hidden. (#1401)
 - Fix: Don't allow following of empty Twitter usernames through the admin page. (#1395)
+- Dev: Updated whisper rate limits to align with Twitch specification of: 3 per second, up to 100 per minute. (#1409)
 
 ## v1.54
 

--- a/pajbot/tmi.py
+++ b/pajbot/tmi.py
@@ -30,5 +30,5 @@ class TMIRateLimits:
 
 
 TMIRateLimits.BASE = TMIRateLimits(privmsg_per_30=90, whispers_per_second=2, whispers_per_minute=90)
-TMIRateLimits.KNOWN = TMIRateLimits(privmsg_per_30=90, whispers_per_second=8, whispers_per_minute=190)
-TMIRateLimits.VERIFIED = TMIRateLimits(privmsg_per_30=7000, whispers_per_second=15, whispers_per_minute=1150)
+TMIRateLimits.KNOWN = TMIRateLimits(privmsg_per_30=90, whispers_per_second=2, whispers_per_minute=90)
+TMIRateLimits.VERIFIED = TMIRateLimits(privmsg_per_30=7000, whispers_per_second=2, whispers_per_minute=90)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

Adjusted whisper rate limits to assign with Twitch's new limits. While old verified bots still have the old whisper limits, unless you're sending that many whispers (for a single channel bot), you shouldn't notice a difference.