### PR TITLE
Update max chunk processing value in pnsl module

### DIFF
--- a/pajbot/modules/pnsl.py
+++ b/pajbot/modules/pnsl.py
@@ -33,7 +33,7 @@ class PNSLModule(BaseModule):
             required=True,
             placeholder="",
             default=30,
-            constraints={"min_value": 1, "max_value": 500},
+            constraints={"min_value": 1, "max_value": 100},
         ),
         ModuleSetting(
             key="chunk_delay",


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

According to this: https://dev.twitch.tv/docs/irc/guide#rate-limits
The new limits are 100/30s per channel for all users.