### PR TITLE
Update verified bot rate limits to align with twitch documentation

### DIFF
--- a/pajbot/tmi.py
+++ b/pajbot/tmi.py
@@ -31,4 +31,4 @@ class TMIRateLimits:
 
 TMIRateLimits.BASE = TMIRateLimits(privmsg_per_30=90, whispers_per_second=2, whispers_per_minute=90)
 TMIRateLimits.KNOWN = TMIRateLimits(privmsg_per_30=90, whispers_per_second=2, whispers_per_minute=90)
-TMIRateLimits.VERIFIED = TMIRateLimits(privmsg_per_30=7000, whispers_per_second=2, whispers_per_minute=90)
+TMIRateLimits.VERIFIED = TMIRateLimits(privmsg_per_30=90, whispers_per_second=2, whispers_per_minute=90)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable

Update limits found here: https://dev.twitch.tv/docs/irc/guide#rate-limits
The 100/30s rule is now implemented per channel, whether the bot is verified or not.