### PR TITLE
Don't lowercase first letter in `send_message_to_user` function

### DIFF
--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -659,14 +659,14 @@ class Bot:
 
     def send_message_to_user(self, user, message, event, method="say"):
         if method == "say":
-            self.say(f"@{user.name}, {lowercase_first_letter(message)}")
+            self.say(f"@{user.name}, {message}")
         elif method == "whisper":
             self.whisper(user, message)
         elif method == "me":
             self.me(message)
         elif method == "reply":
             if event.type in ["action", "pubmsg"]:
-                self.say(f"@{user.name}, {lowercase_first_letter(message)}")
+                self.say(f"@{user.name}, {message}")
             elif event.type == "whisper":
                 self.whisper(user, message)
         else:


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [ ] I have tested all changes

The username is the salutation, therefore the first letter should be capitalized as per proper English. **Should** be, but we shouldn't enforce it, but rather display the message as entered by the user/module.