### PR TITLE
Updated the broadcast manage scope to match updated helix docs

### DIFF
--- a/pajbot/modules/basic/stream_update.py
+++ b/pajbot/modules/basic/stream_update.py
@@ -67,7 +67,7 @@ class StreamUpdateModule(BaseModule):
     ]
 
     def update_game(self, bot: Bot, source, message, **rest) -> Any:
-        if "user:edit:broadcast" not in bot.streamer_access_token_manager.token.scope:
+        if "channel:manage:broadcast" not in bot.streamer_access_token_manager.token.scope:
             bot.say(
                 "Error: The streamer must grant permissions to update the game. The streamer needs to be re-authenticated to fix this problem."
             )
@@ -104,7 +104,7 @@ class StreamUpdateModule(BaseModule):
         AdminLogManager.add_entry("Game set", source, log_msg)
 
     def update_title(self, bot: Bot, source, message, **rest) -> Any:
-        if "user:edit:broadcast" not in bot.streamer_access_token_manager.token.scope:
+        if "channel:manage:broadcast" not in bot.streamer_access_token_manager.token.scope:
             bot.say(
                 "Error: The streamer must grant permissions to update the game. The streamer needs to be re-authenticated to fix this problem."
             )

--- a/pajbot/modules/basic/stream_update.py
+++ b/pajbot/modules/basic/stream_update.py
@@ -69,7 +69,10 @@ class StreamUpdateModule(BaseModule):
     def update_game(self, bot: Bot, source, message, **rest) -> Any:
         auth_error = "Error: The streamer must grant permissions to update the game. The streamer needs to be re-authenticated to fix this problem."
 
-        if "user:edit:broadcast" not in bot.streamer_access_token_manager.token.scope and "channel:manage:broadcast" not in bot.streamer_access_token_manager.token.scope:
+        if (
+            "user:edit:broadcast" not in bot.streamer_access_token_manager.token.scope
+            and "channel:manage:broadcast" not in bot.streamer_access_token_manager.token.scope
+        ):
             bot.say(auth_error)
             return
 
@@ -110,7 +113,10 @@ class StreamUpdateModule(BaseModule):
     def update_title(self, bot: Bot, source, message, **rest) -> Any:
         auth_error = "Error: The streamer must grant permissions to update the title. The streamer needs to be re-authenticated to fix this problem."
 
-        if "user:edit:broadcast" not in bot.streamer_access_token_manager.token.scope and "channel:manage:broadcast" not in bot.streamer_access_token_manager.token.scope:
+        if (
+            "user:edit:broadcast" not in bot.streamer_access_token_manager.token.scope
+            and "channel:manage:broadcast" not in bot.streamer_access_token_manager.token.scope
+        ):
             bot.say(auth_error)
             return
 

--- a/pajbot/modules/basic/stream_update.py
+++ b/pajbot/modules/basic/stream_update.py
@@ -67,7 +67,7 @@ class StreamUpdateModule(BaseModule):
     ]
 
     def update_game(self, bot: Bot, source, message, **rest) -> Any:
-        if "channel:manage:broadcast" not in bot.streamer_access_token_manager.token.scope:
+        if "user:edit:broadcast" or "channel:manage:broadcast" not in bot.streamer_access_token_manager.token.scope:
             bot.say(
                 "Error: The streamer must grant permissions to update the game. The streamer needs to be re-authenticated to fix this problem."
             )
@@ -104,7 +104,7 @@ class StreamUpdateModule(BaseModule):
         AdminLogManager.add_entry("Game set", source, log_msg)
 
     def update_title(self, bot: Bot, source, message, **rest) -> Any:
-        if "channel:manage:broadcast" not in bot.streamer_access_token_manager.token.scope:
+        if "user:edit:broadcast" or "channel:manage:broadcast" not in bot.streamer_access_token_manager.token.scope:
             bot.say(
                 "Error: The streamer must grant permissions to update the game. The streamer needs to be re-authenticated to fix this problem."
             )

--- a/pajbot/modules/basic/stream_update.py
+++ b/pajbot/modules/basic/stream_update.py
@@ -67,7 +67,7 @@ class StreamUpdateModule(BaseModule):
     ]
 
     def update_game(self, bot: Bot, source, message, **rest) -> Any:
-        if "user:edit:broadcast" or "channel:manage:broadcast" not in bot.streamer_access_token_manager.token.scope:
+        if ("user:edit:broadcast" or "channel:manage:broadcast") not in bot.streamer_access_token_manager.token.scope:
             bot.say(
                 "Error: The streamer must grant permissions to update the game. The streamer needs to be re-authenticated to fix this problem."
             )
@@ -104,7 +104,7 @@ class StreamUpdateModule(BaseModule):
         AdminLogManager.add_entry("Game set", source, log_msg)
 
     def update_title(self, bot: Bot, source, message, **rest) -> Any:
-        if "user:edit:broadcast" or "channel:manage:broadcast" not in bot.streamer_access_token_manager.token.scope:
+        if ("user:edit:broadcast" or "channel:manage:broadcast") not in bot.streamer_access_token_manager.token.scope:
             bot.say(
                 "Error: The streamer must grant permissions to update the game. The streamer needs to be re-authenticated to fix this problem."
             )

--- a/pajbot/modules/basic/stream_update.py
+++ b/pajbot/modules/basic/stream_update.py
@@ -67,7 +67,7 @@ class StreamUpdateModule(BaseModule):
     ]
 
     def update_game(self, bot: Bot, source, message, **rest) -> Any:
-        if ("user:edit:broadcast" or "channel:manage:broadcast") not in bot.streamer_access_token_manager.token.scope:
+        if "user:edit:broadcast" not in bot.streamer_access_token_manager.token.scope and "channel:manage:broadcast" not in bot.streamer_access_token_manager.token.scope:
             bot.say(
                 "Error: The streamer must grant permissions to update the game. The streamer needs to be re-authenticated to fix this problem."
             )
@@ -104,7 +104,7 @@ class StreamUpdateModule(BaseModule):
         AdminLogManager.add_entry("Game set", source, log_msg)
 
     def update_title(self, bot: Bot, source, message, **rest) -> Any:
-        if ("user:edit:broadcast" or "channel:manage:broadcast") not in bot.streamer_access_token_manager.token.scope:
+        if "user:edit:broadcast" not in bot.streamer_access_token_manager.token.scope and "channel:manage:broadcast" not in bot.streamer_access_token_manager.token.scope:
             bot.say(
                 "Error: The streamer must grant permissions to update the game. The streamer needs to be re-authenticated to fix this problem."
             )

--- a/pajbot/web/routes/base/login.py
+++ b/pajbot/web/routes/base/login.py
@@ -49,7 +49,7 @@ def init(app):
         "clips:edit",
     ]
 
-    streamer_scopes = ["channel:read:subscriptions", "channel_editor", "user:edit:broadcast"]
+    streamer_scopes = ["channel:read:subscriptions", "channel_editor", "channel:manage:broadcast"]
 
     @app.route("/login")
     def login():


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

It was updated: https://dev.twitch.tv/docs/api/reference#modify-channel-information
The old scope remains valid, but is only officially used for extensions, so better off updating it