### PR TITLE
Handle auth errors for the `!setgame` and `!settitle` commands properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Minor: Improved emote scaling in the CLR overlay. (#1400)
 - Minor: Add option to combine roulette output in offline chat too.
 - Minor: Add option to select which emotes are used for wins and losses in combined roulette output.
+- Bugfix: Fixed 401 errors not being handled correctly for `!setgame` and `!settitle` commands. (#1449)
 - Bugfix: Fixed Linkchecker not timing out with disable warnings checked. (#1433)
 - Bugfix: Fixed incorrect error messages for blocked titles. (#1407)
 - Bugfix: CLR overlay scrollbar is now hidden. (#1401)

--- a/pajbot/apiwrappers/authentication/token_manager.py
+++ b/pajbot/apiwrappers/authentication/token_manager.py
@@ -67,6 +67,12 @@ class AccessTokenManager(ABC):
             self._token = self.fetch_new()
             self.storage.save(self._token)
 
+    def invalidate_token(self):
+        """invalidate_token gives consumes the ability to say that this token
+        has been invalidated externally, and that any further uses
+        of the token must attempt to fetch it from the token storage"""
+        self._token = None
+
     @property
     def token(self):
         """Get a valid token, attempts to load from storage/request a new token on the first call,

--- a/pajbot/modules/basic/stream_update.py
+++ b/pajbot/modules/basic/stream_update.py
@@ -107,7 +107,7 @@ class StreamUpdateModule(BaseModule):
         AdminLogManager.add_entry("Game set", source, log_msg)
 
     def update_title(self, bot: Bot, source, message, **rest) -> Any:
-        auth_error = "Error: The streamer must grant permissions to update the game. The streamer needs to be re-authenticated to fix this problem."
+        auth_error = "Error: The streamer must grant permissions to update the title. The streamer needs to be re-authenticated to fix this problem."
 
         if "user:edit:broadcast" not in bot.streamer_access_token_manager.token.scope:
             bot.say(auth_error)

--- a/pajbot/modules/basic/stream_update.py
+++ b/pajbot/modules/basic/stream_update.py
@@ -67,10 +67,10 @@ class StreamUpdateModule(BaseModule):
     ]
 
     def update_game(self, bot: Bot, source, message, **rest) -> Any:
+        auth_error = "Error: The streamer must grant permissions to update the game. The streamer needs to be re-authenticated to fix this problem."
+
         if "user:edit:broadcast" not in bot.streamer_access_token_manager.token.scope:
-            bot.say(
-                "Error: The streamer must grant permissions to update the game. The streamer needs to be re-authenticated to fix this problem."
-            )
+            bot.say(auth_error)
             return
 
         game_name = message
@@ -92,7 +92,10 @@ class StreamUpdateModule(BaseModule):
                 authorization=bot.streamer_access_token_manager,
             )
         except HTTPError as e:
-            if e.response.status_code == 500:
+            if e.response.status_code == 401:
+                log.error(f"Failed to update game to '{game_name}' - auth error")
+                bot.say(auth_error)
+            elif e.response.status_code == 500:
                 log.error(f"Failed to update game to '{game_name}' - internal server error")
                 bot.say(f"{source}, Failed to update game! Please try again.")
             else:
@@ -104,10 +107,10 @@ class StreamUpdateModule(BaseModule):
         AdminLogManager.add_entry("Game set", source, log_msg)
 
     def update_title(self, bot: Bot, source, message, **rest) -> Any:
+        auth_error = "Error: The streamer must grant permissions to update the game. The streamer needs to be re-authenticated to fix this problem."
+
         if "user:edit:broadcast" not in bot.streamer_access_token_manager.token.scope:
-            bot.say(
-                "Error: The streamer must grant permissions to update the game. The streamer needs to be re-authenticated to fix this problem."
-            )
+            bot.say(auth_error)
             return
 
         title = message
@@ -123,7 +126,10 @@ class StreamUpdateModule(BaseModule):
                 authorization=bot.streamer_access_token_manager,
             )
         except HTTPError as e:
-            if e.response.status_code == 400:
+            if e.response.status_code == 401:
+                log.error(f"Failed to update title to '{title}' - auth error")
+                bot.say(auth_error)
+            elif e.response.status_code == 400:
                 log.error(f"Title '{title}' contains banned words")
                 bot.say(f"{source}, Title contained banned words. Please remove the banned words and try again.")
             elif e.response.status_code == 500:

--- a/pajbot/modules/basic/stream_update.py
+++ b/pajbot/modules/basic/stream_update.py
@@ -95,6 +95,7 @@ class StreamUpdateModule(BaseModule):
             if e.response.status_code == 401:
                 log.error(f"Failed to update game to '{game_name}' - auth error")
                 bot.say(auth_error)
+                bot.streamer_access_token_manager.invalidate_token()
             elif e.response.status_code == 500:
                 log.error(f"Failed to update game to '{game_name}' - internal server error")
                 bot.say(f"{source}, Failed to update game! Please try again.")
@@ -129,6 +130,7 @@ class StreamUpdateModule(BaseModule):
             if e.response.status_code == 401:
                 log.error(f"Failed to update title to '{title}' - auth error")
                 bot.say(auth_error)
+                bot.streamer_access_token_manager.invalidate_token()
             elif e.response.status_code == 400:
                 log.error(f"Title '{title}' contains banned words")
                 bot.say(f"{source}, Title contained banned words. Please remove the banned words and try again.")


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

As it stands, we currently check auth in our own redit entry. If our entry is not up to date, then the bot will still try to set the game/title and will get an auth error from helix. This pr aims to handle said error.