### PR TITLE
Bump python and debian version requirements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: debian:buster
+    container: debian:bullseye
 
     steps:
       - name: Update apt database
@@ -34,7 +34,7 @@ jobs:
 
   check_format:
     runs-on: ubuntu-latest
-    container: debian:buster
+    container: debian:bullseye
 
     steps:
       - name: Update apt database

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: ./venv
-          key: v1-requirements-prod@${{ hashFiles('requirements.txt') }}-dev@${{ hashFiles('requirements-dev.txt') }}
+          key: v2-requirements-prod@${{ hashFiles('requirements.txt') }}-dev@${{ hashFiles('requirements-dev.txt') }}
 
       - name: Install dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -50,7 +50,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: ./venv
-          key: v1-requirements-prod@${{ hashFiles('requirements.txt') }}-dev@${{ hashFiles('requirements-dev.txt') }}
+          key: v2-requirements-prod@${{ hashFiles('requirements.txt') }}-dev@${{ hashFiles('requirements-dev.txt') }}
 
       - name: Install dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Note: pajbot is in **maintenance mode**.
 This means we focus on keeping the project alive by not allowing major overhauls of any pajbot system or any major features.
 Fixing bugs, updating dependencies and ensuring that code interacting with external APIs still function will be our main goal.
 Feature requests will not be accepted unless someone is willing to own the feature, and even then some features that change too much of the architecture won't be allowed.
+Current minimal supported Python version is **3.8**.
 
 ## Quick install
 


### PR DESCRIPTION
Debian version bumped to latest stable (bullseye) and I want to support Python 3.8 and up only. Debian stable has Python 3.9 atm.


Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
