### PR TITLE
Add option to send whispers to control hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
+- Minor: Added option to send whispers to control hub. (#1456)
 - Minor: Added Twitch reply thread support. (#1442)
 - Minor: Added the ability to change the bot response method in the wolfram module. (#1423)
 - Minor: Added the ability to change the bot response method in the math module. (#1421)

--- a/configs/example.ini
+++ b/configs/example.ini
@@ -28,7 +28,7 @@ db = postgresql+psycopg2:///pajbot?options=-c%%20search_path%%3Dpajbot1_streamer
 ; `whisper_output_mode = normal` sends whispers as normal. (This is the default if you don't configure this option)
 ; `whisper_output_mode = disabled` will make it so the bot does not send any whispers. Outgoing whispers will be dropped.
 ; `whisper_output_mode = chat` outputs all messages intended to be whispered to the streamer's chat instead of whispering them.
-; `whisper_output_mode = control` outputs all messages intended to be whispered to the control hub chat instead of whispering them.
+; `whisper_output_mode = control_hub` outputs all messages intended to be whispered to the control hub chat instead of whispering them.
 ;whisper_output_mode = normal
 
 ; Optional section if you want to make the "Wolfram Alpha Query" module available for use:

--- a/configs/example.ini
+++ b/configs/example.ini
@@ -28,6 +28,7 @@ db = postgresql+psycopg2:///pajbot?options=-c%%20search_path%%3Dpajbot1_streamer
 ; `whisper_output_mode = normal` sends whispers as normal. (This is the default if you don't configure this option)
 ; `whisper_output_mode = disabled` will make it so the bot does not send any whispers. Outgoing whispers will be dropped.
 ; `whisper_output_mode = chat` outputs all messages intended to be whispered to the streamer's chat instead of whispering them.
+; `whisper_output_mode = control` outputs all messages intended to be whispered to the control hub chat instead of whispering them.
 ;whisper_output_mode = normal
 
 ; Optional section if you want to make the "Wolfram Alpha Query" module available for use:

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -646,7 +646,7 @@ class Bot:
             self.irc.whisper(user.login, message)
         if self.whisper_output_mode == WhisperOutputMode.CHAT:
             self.privmsg(f"{user}, {message}")
-        if self.whisper_output_mode == WhisperOutputMode.CONTROL:
+        if self.whisper_output_mode == WhisperOutputMode.CONTROL_HUB:
             chub = self.config["main"].get("control_hub", None)
             if chub is not None:
                 chub = f"#{chub}"
@@ -659,7 +659,7 @@ class Bot:
             self.irc.whisper(login, message)
         if self.whisper_output_mode == WhisperOutputMode.CHAT:
             self.privmsg(f"{login}, {message}")
-        if self.whisper_output_mode == WhisperOutputMode.CONTROL:
+        if self.whisper_output_mode == WhisperOutputMode.CONTROL_HUB:
             chub = self.config["main"].get("control_hub", None)
             if chub is not None:
                 chub = f"#{chub}"

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -649,8 +649,13 @@ class Bot:
         if self.whisper_output_mode == WhisperOutputMode.CONTROL_HUB:
             chub = self.config["main"].get("control_hub", None)
             if chub is not None:
-                chub = f"#{chub}"
-            self.privmsg(f"{user}, {message}", chub)
+                self.privmsg(f"{user}, {message}", f"#{chub}")
+            else:
+                log.warning(
+                    "Whisper output mode set to `control_hub` but no control hub configured in config, "
+                    f"the following whisper will not be sent: To {user}: {message}"
+                )
+
         elif self.whisper_output_mode == WhisperOutputMode.DISABLED:
             log.debug(f'Whisper "{message}" to user "{user}" was not sent (due to config setting)')
 
@@ -662,8 +667,12 @@ class Bot:
         if self.whisper_output_mode == WhisperOutputMode.CONTROL_HUB:
             chub = self.config["main"].get("control_hub", None)
             if chub is not None:
-                chub = f"#{chub}"
-            self.privmsg(f"{login}, {message}", chub)
+                self.privmsg(f"{login}, {message}", f"#{chub}")
+            else:
+                log.warning(
+                    "Whisper output mode set to `control_hub` but no control hub configured in config, "
+                    f"the following whisper will not be sent: To {login}: {message}"
+                )
         elif self.whisper_output_mode == WhisperOutputMode.DISABLED:
             log.debug(f'Whisper "{message}" to user "{login}" was not sent (due to config setting)')
 

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -646,6 +646,11 @@ class Bot:
             self.irc.whisper(user.login, message)
         if self.whisper_output_mode == WhisperOutputMode.CHAT:
             self.privmsg(f"{user}, {message}")
+        if self.whisper_output_mode == WhisperOutputMode.CONTROL:
+            chub = self.config["main"].get("control_hub", None)
+            if chub is not None:
+                chub = f"#{chub}"
+            self.privmsg(f"{user}, {message}", chub)
         elif self.whisper_output_mode == WhisperOutputMode.DISABLED:
             log.debug(f'Whisper "{message}" to user "{user}" was not sent (due to config setting)')
 
@@ -654,6 +659,11 @@ class Bot:
             self.irc.whisper(login, message)
         if self.whisper_output_mode == WhisperOutputMode.CHAT:
             self.privmsg(f"{login}, {message}")
+        if self.whisper_output_mode == WhisperOutputMode.CONTROL:
+            chub = self.config["main"].get("control_hub", None)
+            if chub is not None:
+                chub = f"#{chub}"
+            self.privmsg(f"{login}, {message}", chub)
         elif self.whisper_output_mode == WhisperOutputMode.DISABLED:
             log.debug(f'Whisper "{message}" to user "{login}" was not sent (due to config setting)')
 

--- a/pajbot/tmi.py
+++ b/pajbot/tmi.py
@@ -7,6 +7,7 @@ class WhisperOutputMode(Enum):
     DISABLED = 0
     NORMAL = 1
     CHAT = 2
+    CONTROL = 3
 
     @staticmethod
     def from_config_value(config_value):

--- a/pajbot/tmi.py
+++ b/pajbot/tmi.py
@@ -7,7 +7,7 @@ class WhisperOutputMode(Enum):
     DISABLED = 0
     NORMAL = 1
     CHAT = 2
-    CONTROL = 3
+    CONTROL_HUB = 3
 
     @staticmethod
     def from_config_value(config_value):


### PR DESCRIPTION

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

Added the option  `whisper_output_mode = control` to output whispers to control hub since whispers don't work for "new" bots and outputting in the streamer's chat can be annoying.

(Maybe the control_hub channel could be an attribute of the bot class instead of getting it in the config every time we need it...)