### PR TITLE
Use `force_verify` parameter for streamer and bot login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Minor: Moved `!twitterfollow` & `!twitterunfollow` commands to the AdminCommands module; also added command logging. (#1493)
 - Minor: Regex banphrases now support more complex regex features. (#1469)
 - Minor: Added usage examples for `!module` command. (#1484)
+- Minor: Made `/streamer_login` and `/bot_login` endpoints always prompt for user authorization. (#1500)
 - Bugfix: Messages are now trimmed to the Twitch character limit. (#1494)
 - Bugfix: Made `!debug playsound` use default cooldown values (5s global / 15s user). (#1474)
 - Bugfix: Corrected error shown when `whisper_output_mode` setting is invalid. (#1487)

--- a/pajbot/web/routes/base/login.py
+++ b/pajbot/web/routes/base/login.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 
 
 def init(app):
-    def twitch_login(scopes):
+    def twitch_login(scopes, should_verify):
         csrf_token = base64.b64encode(os.urandom(64)).decode("utf-8")
         session["csrf_token"] = csrf_token
 
@@ -30,6 +30,7 @@ def init(app):
             "response_type": "code",
             "scope": " ".join(scopes),
             "state": json.dumps(state),
+            "force_verify": "true" if should_verify else "false",
         }
 
         authorize_url = "https://id.twitch.tv/oauth2/authorize?" + urllib.parse.urlencode(params)
@@ -51,15 +52,15 @@ def init(app):
 
     @app.route("/login")
     def login():
-        return twitch_login(scopes=[])
+        return twitch_login(scopes=[], should_verify=False)
 
     @app.route("/bot_login")
     def bot_login():
-        return twitch_login(scopes=bot_scopes)
+        return twitch_login(scopes=bot_scopes, should_verify=True)
 
     @app.route("/streamer_login")
     def streamer_login():
-        return twitch_login(scopes=streamer_scopes)
+        return twitch_login(scopes=streamer_scopes, should_verify=True)
 
     @app.route("/login/authorized")
     def authorized():


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

This will always prompt user to confirm the authorization, even if they're already accepted it before.
While it adds an extra click every time, it can help in case of debugging the login or when streamer wants to relog after their previous oauth token got invalid (due to a ban) without the need to remove pajbot1 from connections under the Twitch account.
