### PR TITLE
Add missing typestubs for colorama/bs4/httplib2

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -37,9 +37,6 @@ ignore_missing_imports = True
 [mypy-tweepy.*]
 ignore_missing_imports = True
 
-[mypy-httplib2.*]
-ignore_missing_imports = True
-
 [mypy-isodate.*]
 ignore_missing_imports = True
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,3 +19,4 @@ sqlalchemy-stubs==0.4
 types-psycopg2==2.9.1
 types-colorama==0.4.3
 types-beautifulsoup4==4.10.1
+types-httplib2==0.19.0


### PR DESCRIPTION
- .mypy.ini sqlalchemy: Remove ignore_missing_imports
- .mypy.ini psycopg2: Remove ignore_missing_imports
- .mypy.ini colorama: Remove ignore_missing_imports
- .mypy.ini bs4: Remove ignore_missing_imports
- .mypy.ini httplib2: Remove ignore_missing_imports



Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
