### PR TITLE
Add streamer config fallback

### DIFF
--- a/pajbot/web/__init__.py
+++ b/pajbot/web/__init__.py
@@ -81,8 +81,13 @@ def init(args):
         with open(args.config, "w") as configfile:
             config.write(configfile)
 
-    streamer = config["main"]["streamer"]
     streamer_display = config["web"]["streamer_name"]
+
+    if not config["main"]["streamer"]:
+        streamer = streamer_display.lower()
+    else:
+        streamer = config["main"]["streamer"]
+
     streamer_user_id = twitch_helix_api.get_user_id(streamer)
     if streamer_user_id is None:
         raise ValueError("The streamer login name you entered under [main] does not exist on twitch.")


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [ ] I have tested all changes

Should the bot admin not input a `streamer` in the config file, the bot will attempt to use the `streamer_display` config option. This also means that it is no longer required to input the `streamer` in the config file (providing there's no Asian characters in the display name.

It'd be worth just moving to IDs at some point in order to simplify the process.