### PR TITLE
Store secret key in redis instead of the config file

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -16,9 +16,6 @@ ignore_missing_imports = True
 [mypy-flask_restful.*]
 ignore_missing_imports = True
 
-[mypy-flask_scrypt.*]
-ignore_missing_imports = True
-
 [mypy-Levenshtein.*]
 ignore_missing_imports = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 
 - Minor: Allow configuring streamer, bot, admin, and control hub using Twitch User IDs instead of Twitch User Logins. **Specifying user logins in the config has therefore now been deprecated and may stop working in a future release.** (#1590)
 - Bugfix: Fix tweet-manager streaming if bot follows non-existent twitter users. (#1589)
+- Dev: Replaced Flask-Scrypt with the built-in secrets module to generate the secret_key in the config file.
 - Dev: Remove PyScss dependency, fixing Python 3.10 support. (#1602)
 
 ## v1.58

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 
 - Minor: Allow configuring streamer, bot, admin, and control hub using Twitch User IDs instead of Twitch User Logins. **Specifying user logins in the config has therefore now been deprecated and may stop working in a future release.** (#1590)
 - Bugfix: Fix tweet-manager streaming if bot follows non-existent twitter users. (#1589)
-- Dev: Replaced Flask-Scrypt with the built-in secrets module to generate the Flask secret key.
-- Dev: The flask secret key is now stored in redis instead of in the config.ini file.
+- Dev: Replaced Flask-Scrypt with the built-in secrets module to generate the Flask secret key. (#1613)
+- Dev: The flask secret key is now stored in redis instead of in the config.ini file. (#1613)
 - Dev: Remove PyScss dependency, fixing Python 3.10 support. (#1602)
 
 ## v1.58

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 
 - Minor: Allow configuring streamer, bot, admin, and control hub using Twitch User IDs instead of Twitch User Logins. **Specifying user logins in the config has therefore now been deprecated and may stop working in a future release.** (#1590)
 - Bugfix: Fix tweet-manager streaming if bot follows non-existent twitter users. (#1589)
-- Dev: Replaced Flask-Scrypt with the built-in secrets module to generate the secret_key in the config file.
+- Dev: Replaced Flask-Scrypt with the built-in secrets module to generate the Flask secret key.
+- Dev: The flask secret key is now stored in redis instead of in the config.ini file.
 - Dev: Remove PyScss dependency, fixing Python 3.10 support. (#1602)
 
 ## v1.58

--- a/pajbot/web/__init__.py
+++ b/pajbot/web/__init__.py
@@ -32,9 +32,10 @@ def init(args):
     import subprocess
     import sys
 
+    from secrets import token_urlsafe
+
     from flask import request
     from flask import session
-    from flask_scrypt import generate_random_salt
 
     import pajbot.utils
     import pajbot.web.common
@@ -75,8 +76,7 @@ def init(args):
         sys.exit(1)
 
     if "secret_key" not in config["web"]:
-        salt = generate_random_salt()
-        config.set("web", "secret_key", salt.decode("utf-8"))
+        config.set("web", "secret_key", token_urlsafe(64))
 
         with open(args.config, "w") as configfile:
             config.write(configfile)

--- a/pajbot/web/__init__.py
+++ b/pajbot/web/__init__.py
@@ -124,12 +124,10 @@ def init(args):
     app.bot_commands_list = []
     app.bot_config = config
 
-    secret_key = _load_secret_key(app.bot_user.id, app.streamer.id)
-
     # https://flask.palletsprojects.com/en/1.1.x/quickstart/#sessions
     # https://flask.palletsprojects.com/en/1.1.x/api/#sessions
     # https://flask.palletsprojects.com/en/1.1.x/api/#flask.Flask.secret_key
-    app.secret_key = secret_key
+    app.secret_key = _load_secret_key(app.bot_user.id, app.streamer.id)
     app.bot_dev = "flags" in config and "dev" in config["flags"] and config["flags"]["dev"] == "1"
 
     DBManager.init(config["main"]["db"])

--- a/pajbot/web/__init__.py
+++ b/pajbot/web/__init__.py
@@ -28,11 +28,27 @@ app.url_map.strict_slashes = False
 log = logging.getLogger(__name__)
 
 
+def _load_secret_key(bot_id: str, streamer_id: str) -> str:
+    from secrets import token_urlsafe
+
+    from pajbot.managers.redis import RedisManager
+
+    redis = RedisManager.get()
+
+    key = f"web_secret_key:{bot_id}:{streamer_id}"
+
+    value = redis.get(key)
+
+    if value is None:
+        value = token_urlsafe(64)
+        redis.set(key, value)
+
+    return value
+
+
 def init(args):
     import subprocess
     import sys
-
-    from secrets import token_urlsafe
 
     from flask import request
     from flask import session
@@ -75,12 +91,6 @@ def init(args):
         log.error("Missing [web] section in config.ini")
         sys.exit(1)
 
-    if "secret_key" not in config["web"]:
-        config.set("web", "secret_key", token_urlsafe(64))
-
-        with open(args.config, "w") as configfile:
-            config.write(configfile)
-
     app.streamer = cfg.load_streamer(config, twitch_helix_api)
 
     app.streamer_display = app.streamer.name
@@ -110,10 +120,13 @@ def init(args):
     app.bot_modules = config["web"].get("modules", "").split()
     app.bot_commands_list = []
     app.bot_config = config
+
+    secret_key = _load_secret_key(app.bot_user.id, app.streamer.id)
+
     # https://flask.palletsprojects.com/en/1.1.x/quickstart/#sessions
     # https://flask.palletsprojects.com/en/1.1.x/api/#sessions
     # https://flask.palletsprojects.com/en/1.1.x/api/#flask.Flask.secret_key
-    app.secret_key = config["web"]["secret_key"]
+    app.secret_key = secret_key
     app.bot_dev = "flags" in config and "dev" in config["flags"] and config["flags"]["dev"] == "1"
 
     DBManager.init(config["main"]["db"])

--- a/pajbot/web/__init__.py
+++ b/pajbot/web/__init__.py
@@ -13,6 +13,9 @@ from pajbot.utils import extend_version_if_possible
 from flask import Flask
 from flask_wtf.csrf import CSRFProtect
 
+# 30 days
+SECRET_KEY_EXPIRY_SECONDS = 86400 * 30
+
 app = Flask(
     __name__,
     static_folder=os.path.join(os.path.dirname(os.path.abspath(__file__ + "/../..")), "static"),
@@ -41,7 +44,7 @@ def _load_secret_key(bot_id: str, streamer_id: str) -> str:
 
     if value is None:
         value = token_urlsafe(64)
-        redis.set(key, value)
+        redis.set(key, value, ex=SECRET_KEY_EXPIRY_SECONDS)
 
     return value
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ cssmin==0.2.0
 Flask==2.0.2
 Flask-Assets==2.0
 Flask-RESTful==0.3.9
-Flask-Scrypt==0.1.3.6
 httplib2==0.20.2
 irc==19.0.1
 isodate==0.6.0


### PR DESCRIPTION
- Replace Flask-Scrypt with python secrets
- Update changelog
- load/save secret key in redis instead of in the config.ini file
- Expire the secret key after 30 days
- Update changelog entries

Fixes #1575


Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
