### PR TITLE
Fix the bot downgrading bot scopes when logging in on the normal `/login` page using the bot account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 
 - Minor: The `redirect_uri` config option under the `[twitchapi]` section is now optional with a sane default value: `https://<domain>/login/authorized`. (#1618, #1666)
 - Minor: Allow configuring streamer, bot, admin, and control hub using Twitch User IDs instead of Twitch User Logins. **Specifying user logins in the config has therefore now been deprecated and may stop working in a future release.** (#1590)
+- Bugfix: Fix the bot downgrading bot scopes when logging in on the normal `/login` page using the bot account. (#1669)
 - Bugfix: Added an error for a title being too long. (#1638)
 - Bugfix: Fix tweet-manager streaming if bot follows non-existent twitter users. (#1589)
 - Dev: Replaced Flask-Scrypt with the built-in secrets module to generate the Flask secret key. (#1613)

--- a/pajbot/web/routes/base/login.py
+++ b/pajbot/web/routes/base/login.py
@@ -143,9 +143,15 @@ def init(app):
 
         # bot login
         if me.login == app.bot_user.login.lower():
-            redis = RedisManager.get()
-            redis.set(f"authentication:user-access-token:{me.id}", json.dumps(access_token.jsonify()))
-            log.info("Successfully updated bot token in redis")
+            # There's a possibility the owner of the bot account will login using the normal login button.
+            # We only want to update their access token if the returned scope contains the special scopes requested
+            # in /bot_login
+            if set(access_token.scope) < set(bot_scopes):
+                log.info("Bot account logged in but not all scopes present, will not update bot token")
+            else:
+                redis = RedisManager.get()
+                redis.set(f"authentication:user-access-token:{me.id}", json.dumps(access_token.jsonify()))
+                log.info("Successfully updated bot token in redis")
 
         # streamer login
         if me.login == app.streamer.login.lower():

--- a/pajbot/web/routes/base/login.py
+++ b/pajbot/web/routes/base/login.py
@@ -141,35 +141,26 @@ def init(app):
             me = User.from_basics(db_session, user_basics)
             session["user"] = me.jsonify()
 
-        # bot login
-        if me.login == app.bot_user.login.lower():
-            # There's a possibility the owner of the bot account will login using the normal login button.
-            # We only want to update their access token if the returned scope contains the special scopes requested
-            # in /bot_login
-            if set(access_token.scope) < set(bot_scopes):
-                log.info("Bot account logged in but not all scopes present, will not update bot token")
+        required_user_scopes = {
+            # Bot
+            app.bot_user.login.lower(): set(bot_scopes),
+            # Streamer
+            app.streamer.login.lower(): set(streamer_scopes),
+        }
+
+        if me.login in required_user_scopes:
+            # Stop the user from accidentally downgrading their scopes when logging in with
+            # the Streamer or Bot account on the normal /login page
+            required_scopes = required_user_scopes[me.login]
+
+            if set(access_token.scope) < required_scopes:
+                log.info(
+                    f"User {me.login} logged in but not all of their required scopes are present, will not update redis token"
+                )
             else:
                 redis = RedisManager.get()
                 redis.set(f"authentication:user-access-token:{me.id}", json.dumps(access_token.jsonify()))
-                log.info("Successfully updated bot token in redis")
-
-        # streamer login
-        if me.login == app.streamer.login.lower():
-            # there's a good chance the streamer will later log in using the normal login button.
-            # we only update their access token if the returned scope containes the special scopes requested
-            # in /streamer_login
-
-            # We use < to say "if the granted scope is a proper subset of the required scopes", this can be case
-            # for example when the bot is running in its own channel and you use /bot_login,
-            # then the granted scopes will be a superset of the scopes needed for the streamer.
-            # By doing this, both the streamer and bot token will be set if you complete /bot_login with the bot
-            # account, and if the bot is running in its own channel.
-            if set(access_token.scope) < set(streamer_scopes):
-                log.info("Streamer logged in but not all scopes present, will not update streamer token")
-            else:
-                redis = RedisManager.get()
-                redis.set(f"authentication:user-access-token:{me.id}", json.dumps(access_token.jsonify()))
-                log.info("Successfully updated streamer token in redis")
+                log.info(f"Successfully updated {me.login}'s token in redis to {access_token.scope}")
 
         return redirect(return_to)
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

We have protections in place for the streamer's scopes being overriden. I've come across an issue recently where a user had logged into the web panel using the bot account - thus resetting the scopes. This aims to fix anything accidental like this.