### PR TITLE
Add a default chat states module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Minor: Add a default chat states module. This allows automation of otherwise manually triggered things; e.g. enabling emote only at the end of a stream.
+- Minor: Add a default chat states module. This allows automation of otherwise manually triggered things; e.g. enabling emote only at the end of a stream. (#1716)
 - Minor: Add a global command cooldown module. This allows you to share a cooldown between selected commands. (#1714)
 - Minor: Add the QueUp module back. (#1570)
 - Bugfix: Fix social media handles not saving. (#1680)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
+- Minor: Add a default chat states module. This allows automation of otherwise manually triggered things; e.g. enabling emote only at the end of a stream.
 - Minor: Add a global command cooldown module. This allows you to share a cooldown between selected commands. (#1714)
 - Minor: Add the QueUp module back. (#1570)
 - Bugfix: Fix social media handles not saving. (#1680)

--- a/pajbot/modules/__init__.py
+++ b/pajbot/modules/__init__.py
@@ -32,6 +32,7 @@ from pajbot.modules.clr_overlay.emotecombo import EmoteComboModule
 from pajbot.modules.clr_overlay.emotesonscreen import EmotesOnScreenModule
 from pajbot.modules.clr_overlay.showemote import ShowEmoteModule
 from pajbot.modules.deck import DeckModule
+from pajbot.modules.default_chat_states import DefaultChatStatesModule
 from pajbot.modules.duel import DuelModule
 from pajbot.modules.dummy import DummyModule
 from pajbot.modules.eightball import EightBallModule
@@ -101,6 +102,7 @@ available_modules = [
     DBManageModule,
     DebugModule,
     DeckModule,
+    DefaultChatStatesModule,
     DuelModule,
     DummyModule,
     EightBallModule,

--- a/pajbot/modules/default_chat_states.py
+++ b/pajbot/modules/default_chat_states.py
@@ -91,15 +91,13 @@ class DefaultChatStatesModule(BaseModule):
             self.bot.privmsg(".uniquechat")
 
         if self.settings["slow_option"] == "Going Online":
-            slow_time = self.settings["slow_time"]
-            self.bot.privmsg(f".slow {slow_time}")
+            self.bot.privmsg(f".slow {self.settings['slow_time']}")
 
         if self.settings["followersonly_option"] == "Going Online":
             if self.settings["followersonly_time"] == "":
                 self.bot.privmsg(".followers")
             else:
-                follower_time = self.settings["followersonly_time"]
-                self.bot.privmsg(f".followers {follower_time}")
+                self.bot.privmsg(f".followers {self.settings['followersonly_time']}")
 
     def on_stream_stop(self, **rest):
         if self.settings["emoteonly"] == "Going Offline":
@@ -112,15 +110,13 @@ class DefaultChatStatesModule(BaseModule):
             self.bot.privmsg(".uniquechat")
 
         if self.settings["slow_option"] == "Going Offline":
-            slow_time = self.settings["slow_time"]
-            self.bot.privmsg(f".slow {slow_time}")
+            self.bot.privmsg(f".slow {self.settings['slow_time']}")
 
         if self.settings["followersonly_option"] == "Going Offline":
             if self.settings["followersonly_time"] == "":
                 self.bot.privmsg(".followers")
             else:
-                follower_time = self.settings["followersonly_time"]
-                self.bot.privmsg(f".followers {follower_time}")
+                self.bot.privmsg(f".followers {self.settings['followersonly_time']}")
 
     def enable(self, bot):
         HandlerManager.add_handler("on_stream_start", self.on_stream_start)

--- a/pajbot/modules/default_chat_states.py
+++ b/pajbot/modules/default_chat_states.py
@@ -52,7 +52,7 @@ class DefaultChatStatesModule(BaseModule):
             required=True,
             placeholder=30,
             default=30,
-            constraints={"min_value": 1, "max_value": 1800}
+            constraints={"min_value": 1, "max_value": 1800},
         ),
         ModuleSetting(
             key="followersonly_option",

--- a/pajbot/modules/default_chat_states.py
+++ b/pajbot/modules/default_chat_states.py
@@ -50,7 +50,7 @@ class DefaultChatStatesModule(BaseModule):
             label="Amount of seconds to use when setting slow mode",
             type="number",
             required=True,
-            placeholder=30,
+            placeholder="30",
             default=30,
             constraints={"min_value": 1, "max_value": 1800},
         ),

--- a/pajbot/modules/default_chat_states.py
+++ b/pajbot/modules/default_chat_states.py
@@ -1,0 +1,127 @@
+import logging
+
+from pajbot.managers.handler import HandlerManager
+from pajbot.modules import BaseModule, ModuleSetting
+
+log = logging.getLogger(__name__)
+
+
+class DefaultChatStatesModule(BaseModule):
+    ID = __name__.split(".")[-1]
+    NAME = "Default Chat States"
+    DESCRIPTION = "Enforces certain chat states when the streamer goes online/offline"
+    CATEGORY = "Moderation"
+    ENABLED_DEFAULT = False
+    SETTINGS = [
+        ModuleSetting(
+            key="emoteonly",
+            label="Enable emote only mode when the stream is:",
+            type="options",
+            required=True,
+            default="Don't Change",
+            options=["Going Online", "Going Offline", "Don't Change"],
+        ),
+        ModuleSetting(
+            key="subonly",
+            label="Enable subscriber only mode when the stream is:",
+            type="options",
+            required=True,
+            default="Don't Change",
+            options=["Going Online", "Going Offline", "Don't Change"],
+        ),
+        ModuleSetting(
+            key="r9k",
+            label="Enable R9K mode when the stream is:",
+            type="options",
+            required=True,
+            default="Don't Change",
+            options=["Going Online", "Going Offline", "Don't Change"],
+        ),
+        ModuleSetting(
+            key="slow_option",
+            label="Enable slow mode when the stream is:",
+            type="options",
+            required=True,
+            default="Don't Change",
+            options=["Going Online", "Going Offline", "Don't Change"],
+        ),
+        ModuleSetting(
+            key="slow_time",
+            label="Amount of seconds to use when setting slow mode",
+            type="number",
+            required=True,
+            placeholder=30,
+            default=30,
+            constraints={"min_value": 1, "max_value": 1800}
+        ),
+        ModuleSetting(
+            key="followersonly_option",
+            label="Enable followers only mode when the stream is:",
+            type="options",
+            required=True,
+            default="Don't Change",
+            options=["Going Online", "Going Offline", "Don't Change"],
+        ),
+        ModuleSetting(
+            key="followersonly_time",
+            label="Amount of time to use when setting followers only mode | Format is number followed by time format. E.g. 30m, 1 week, 5 days 12 hours",
+            type="text",
+            required=False,
+            placeholder="",
+            default="",
+            constraints={},
+        ),
+    ]
+
+    def __init__(self, bot):
+        super().__init__(bot)
+
+    def on_stream_start(self, **rest):
+        if self.settings["emoteonly"] == "Going Online":
+            self.bot.privmsg(".emoteonly")
+
+        if self.settings["subonly"] == "Going Online":
+            self.bot.privmsg(".subonly")
+
+        if self.settings["r9k"] == "Going Online":
+            self.bot.privmsg(".uniquechat")
+
+        if self.settings["slow_option"] == "Going Online":
+            slow_time = self.settings["slow_time"]
+            self.bot.privmsg(f".slow {slow_time}")
+
+        if self.settings["followersonly_option"] == "Going Online":
+            if self.settings["followersonly_time"] == "":
+                self.bot.privmsg(".followers")
+            else:
+                follower_time = self.settings["followersonly_time"]
+                self.bot.privmsg(f".followers {follower_time}")
+
+    def on_stream_stop(self, **rest):
+        if self.settings["emoteonly"] == "Going Offline":
+            self.bot.privmsg(".emoteonly")
+
+        if self.settings["subonly"] == "Going Offline":
+            self.bot.privmsg(".subonly")
+
+        if self.settings["r9k"] == "Going Offline":
+            self.bot.privmsg(".uniquechat")
+
+        if self.settings["slow_option"] == "Going Offline":
+            slow_time = self.settings["slow_time"]
+            self.bot.privmsg(f".slow {slow_time}")
+
+        if self.settings["followersonly_option"] == "Going Offline":
+            if self.settings["followersonly_time"] == "":
+                self.bot.privmsg(".followers")
+            else:
+                follower_time = self.settings["followersonly_time"]
+                self.bot.privmsg(f".followers {follower_time}")
+
+    def enable(self, bot):
+        HandlerManager.add_handler("on_stream_start", self.on_stream_start)
+        HandlerManager.add_handler("on_stream_stop", self.on_stream_stop)
+
+    def disable(self, bot):
+        HandlerManager.remove_handler("on_stream_start", self.on_stream_start)
+        HandlerManager.remove_handler("on_stream_stop", self.on_stream_stop)

--- a/pajbot/modules/default_chat_states.py
+++ b/pajbot/modules/default_chat_states.py
@@ -92,19 +92,19 @@ class DefaultChatStatesModule(BaseModule):
             log.warning("on_stream_start failed in DefaultChatStatesModule because bot is None")
             return True
 
-        if self.settings["emoteonly"] == "Going Online":
+        if self.settings["emoteonly"] == self.ONLINE_PHRASE:
             self.bot.privmsg(".emoteonly")
 
-        if self.settings["subonly"] == "Going Online":
+        if self.settings["subonly"] == self.ONLINE_PHRASE:
             self.bot.privmsg(".subonly")
 
-        if self.settings["r9k"] == "Going Online":
+        if self.settings["r9k"] == self.ONLINE_PHRASE:
             self.bot.privmsg(".uniquechat")
 
-        if self.settings["slow_option"] == "Going Online":
+        if self.settings["slow_option"] == self.ONLINE_PHRASE:
             self.bot.privmsg(f".slow {self.settings['slow_time']}")
 
-        if self.settings["followersonly_option"] == "Going Online":
+        if self.settings["followersonly_option"] == self.ONLINE_PHRASE:
             if self.settings["followersonly_time"] == "":
                 self.bot.privmsg(".followers")
             else:
@@ -117,19 +117,19 @@ class DefaultChatStatesModule(BaseModule):
             log.warning("on_stream_stop failed in DefaultChatStatesModule because bot is None")
             return True
 
-        if self.settings["emoteonly"] == "Going Offline":
+        if self.settings["emoteonly"] == self.OFFLINE_PHRASE:
             self.bot.privmsg(".emoteonly")
 
-        if self.settings["subonly"] == "Going Offline":
+        if self.settings["subonly"] == self.OFFLINE_PHRASE:
             self.bot.privmsg(".subonly")
 
-        if self.settings["r9k"] == "Going Offline":
+        if self.settings["r9k"] == self.OFFLINE_PHRASE:
             self.bot.privmsg(".uniquechat")
 
-        if self.settings["slow_option"] == "Going Offline":
+        if self.settings["slow_option"] == self.OFFLINE_PHRASE:
             self.bot.privmsg(f".slow {self.settings['slow_time']}")
 
-        if self.settings["followersonly_option"] == "Going Offline":
+        if self.settings["followersonly_option"] == self.OFFLINE_PHRASE:
             if self.settings["followersonly_time"] == "":
                 self.bot.privmsg(".followers")
             else:

--- a/pajbot/modules/default_chat_states.py
+++ b/pajbot/modules/default_chat_states.py
@@ -12,38 +12,42 @@ class DefaultChatStatesModule(BaseModule):
     DESCRIPTION = "Enforces certain chat states when the streamer goes online/offline"
     CATEGORY = "Moderation"
     ENABLED_DEFAULT = False
+    ONLINE_PHRASE = "Goes Online"
+    OFFLINE_PHRASE = "Goes Offline"
+    NEVER_PHRASE = "Never"
+    PHRASE_OPTIONS = [ONLINE_PHRASE, OFFLINE_PHRASE, NEVER_PHRASE]
     SETTINGS = [
         ModuleSetting(
             key="emoteonly",
-            label="Enable emote only mode when the stream is:",
+            label="Enable emote only mode when the stream...",
             type="options",
             required=True,
-            default="Don't Change",
-            options=["Going Online", "Going Offline", "Don't Change"],
+            default=NEVER_PHRASE,
+            options=PHRASE_OPTIONS,
         ),
         ModuleSetting(
             key="subonly",
-            label="Enable subscriber only mode when the stream is:",
+            label="Enable subscriber only mode when the stream...",
             type="options",
             required=True,
-            default="Don't Change",
-            options=["Going Online", "Going Offline", "Don't Change"],
+            default=NEVER_PHRASE,
+            options=PHRASE_OPTIONS,
         ),
         ModuleSetting(
             key="r9k",
-            label="Enable R9K mode when the stream is:",
+            label="Enable R9K mode when the stream...",
             type="options",
             required=True,
-            default="Don't Change",
-            options=["Going Online", "Going Offline", "Don't Change"],
+            default=NEVER_PHRASE,
+            options=PHRASE_OPTIONS,
         ),
         ModuleSetting(
             key="slow_option",
-            label="Enable slow mode when the stream is:",
+            label="Enable slow mode when the stream...",
             type="options",
             required=True,
-            default="Don't Change",
-            options=["Going Online", "Going Offline", "Don't Change"],
+            default=NEVER_PHRASE,
+            options=PHRASE_OPTIONS,
         ),
         ModuleSetting(
             key="slow_time",
@@ -56,11 +60,11 @@ class DefaultChatStatesModule(BaseModule):
         ),
         ModuleSetting(
             key="followersonly_option",
-            label="Enable followers only mode when the stream is:",
+            label="Enable followers only mode when the stream...",
             type="options",
             required=True,
-            default="Don't Change",
-            options=["Going Online", "Going Offline", "Don't Change"],
+            default=NEVER_PHRASE,
+            options=PHRASE_OPTIONS,
         ),
         ModuleSetting(
             key="followersonly_time",


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

This will enable automation of otherwise mundane tasks that mods/streamers may forget to do. E.g. turning on emote only at the end of a stream or turning on sub only at the start of a stream.