### PR TITLE
Change rapidfuzz ratio from 0.94 to 94

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Minor: Add the QueUp module back. (#1570)
 - Bugfix: Fix social media handles not saving. (#1680)
 - Dev: Add import sorting to format checker. (#1715)
+- Dev: Replaced Levenshtein module with rapidfuzz. (#1718)
 
 ## v1.59
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Minor: Add the QueUp module back. (#1570)
 - Bugfix: Fix social media handles not saving. (#1680)
 - Dev: Add import sorting to format checker. (#1715)
-- Dev: Replaced Levenshtein module with rapidfuzz. (#1718)
+- Dev: Replaced Levenshtein dependency with rapidfuzz. (#1713, #1718)
 
 ## v1.59
 

--- a/pajbot/modules/trivia.py
+++ b/pajbot/modules/trivia.py
@@ -214,7 +214,7 @@ class TriviaModule(BaseModule):
                 correct = right_answer == user_answer
             else:
                 ratio = rapidfuzz.fuzz.ratio(right_answer, user_answer)
-                correct = ratio >= 0.94
+                correct = ratio >= 94
 
             if correct:
                 if self.point_bounty > 0:


### PR DESCRIPTION
Unlike Levenshtein, the rapidfuzz package's ratio method returns the similarity between [0, 100] and not [0, 1]



Pull request checklist:

- [X] `CHANGELOG.md` was updated, if applicable
- [X] Documentation in docs/ or install-docs/ was updated, if applicable
- [X] I have tested all changes

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
