### PR TITLE
Emote blocklist and allowlist for all CLR Overlay modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Minor: Add the QueUp module back. (#1570)
 - Minor: Added Open Graph metadata to improve look in embeds such as in Twitter and Discord. (#1721)
 - Minor: `websocket.unix_socket` config option now has a default value (`/var/run/pajbot/<streamer>/websocket.sock`). (#1739)
+- Minor: CLR Overlay modules (i.e. Emote Combos, Emotes on Screen, and Show Emote) now all have a separate allowlist and blocklist of emotes. If the allowlist and blocklist from each specific module isn't used, they will use the shared parent module "CLR Overlay" allowlist and blocklist instead. (#1741)
 - Bugfix: Fix social media handles not saving. (#1680)
 - Bugfix: Notifications will no longer overflow on the CLR overlay. (#1719)
 - Dev: Add import sorting to format checker. (#1715)

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -231,7 +231,8 @@ class Bot:
         self.epm_manager = EpmManager()
         self.ecount_manager = EcountManager()
         self.twitter_manager = cfg.load_twitter_manager(config)(self)
-        self.module_manager = ModuleManager(self.socket_manager, bot=self).load()
+        self.module_manager = ModuleManager(self.socket_manager, bot=self)
+        self.module_manager.load()
         self.commands = CommandManager(
             socket_manager=self.socket_manager, module_manager=self.module_manager, bot=self
         ).load()

--- a/pajbot/managers/emote.py
+++ b/pajbot/managers/emote.py
@@ -7,14 +7,12 @@ import random
 
 from pajbot.managers.redis import RedisManager
 from pajbot.managers.schedule import ScheduleManager
-from pajbot.models.emote import Emote, EmoteInstance, EmoteInstanceCount
+from pajbot.models.emote import Emote, EmoteInstance, EmoteInstanceCount, EmoteInstanceCountMap
 from pajbot.streamhelper import StreamHelper
 from pajbot.utils import iterate_split_with_index
 
 if TYPE_CHECKING:
     from pajbot.apiwrappers.twitch.helix import TwitchHelixAPI
-
-EmoteInstanceCountMap = Dict[str, EmoteInstanceCount]
 
 log = logging.getLogger(__name__)
 

--- a/pajbot/models/emote.py
+++ b/pajbot/models/emote.py
@@ -107,3 +107,6 @@ class EmoteInstanceCount:
             "emote": self.emote.jsonify(),
             "emote_instances": [i.jsonify() for i in self.emote_instances],
         }
+
+
+EmoteInstanceCountMap = Dict[str, EmoteInstanceCount]

--- a/pajbot/models/module.py
+++ b/pajbot/models/module.py
@@ -59,6 +59,7 @@ class ModuleManager:
 
             if module:
                 module.load()
+                module.on_loaded()
 
     def enable_module(self, module_id: str) -> bool:
         module = self.get_module(module_id)
@@ -67,6 +68,7 @@ class ModuleManager:
             return False
 
         module.load()
+        module.on_loaded()
 
         module.enable(self.bot)
 
@@ -135,6 +137,7 @@ class ModuleManager:
                             log.warning("Invalid JSON")
 
                     self.modules.append(module.load(**options))
+                    module.on_loaded()
                     module.enable(self.bot)
 
     def _disable_orphan_modules(self) -> None:

--- a/pajbot/modules/clr_overlay/__init__.py
+++ b/pajbot/modules/clr_overlay/__init__.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, Optional, Set
+
 import logging
 
 from pajbot.modules import BaseModule
-from pajbot.modules.base import ModuleType
+from pajbot.modules.base import ModuleSetting, ModuleType
+
+if TYPE_CHECKING:
+    from pajbot.bot import Bot
 
 log = logging.getLogger(__name__)
 
@@ -13,3 +20,59 @@ class CLROverlayModule(BaseModule):
     CATEGORY = "Feature"
     ENABLED_DEFAULT = True
     MODULE_TYPE = ModuleType.TYPE_ALWAYS_ENABLED
+
+    BASE_ALLOWLIST_LABEL: str = "Allowlisted emotes (separate by spaces). Leave empty to use the blocklist."
+    BASE_BLOCKLIST_LABEL: str = "Blocklisted emotes (separate by spaces). Leave empty to allow all emotes."
+    ALLOWLIST_LABEL: str = f"{BASE_ALLOWLIST_LABEL} If this and the blocklist are empty, the parent module's allow and blocklist will be used."
+    BLOCKLIST_LABEL: str = f"{BASE_BLOCKLIST_LABEL} If this and the allowlist are empty, the parent module's allow and blocklist will be used."
+
+    EMOTELIST_PLACEHOLDER_TEXT: str = "e.g. Kappa Keepo PogChamp KKona"
+
+    SETTINGS = [
+        ModuleSetting(
+            key="emote_allowlist",
+            label=BASE_ALLOWLIST_LABEL,
+            type="text",
+            required=True,
+            placeholder=EMOTELIST_PLACEHOLDER_TEXT,
+            default="",
+        ),
+        ModuleSetting(
+            key="emote_blocklist",
+            label=BASE_BLOCKLIST_LABEL,
+            type="text",
+            required=True,
+            placeholder=EMOTELIST_PLACEHOLDER_TEXT,
+            default="",
+        ),
+    ]
+
+    def __init__(self, bot: Optional[Bot]) -> None:
+        super().__init__(bot)
+
+        self.allowlisted_emotes: Set[str] = set()
+        self.blocklisted_emotes: Set[str] = set()
+
+    def on_loaded(self) -> None:
+        self.allowlisted_emotes = set(
+            self.settings["emote_allowlist"].strip().split(" ") if self.settings["emote_allowlist"] else []
+        )
+        self.blocklisted_emotes = set(
+            self.settings["emote_blocklist"].strip().split(" ") if self.settings["emote_blocklist"] else []
+        )
+
+    def is_emote_allowed(self, emote_code: str) -> bool:
+        if len(self.allowlisted_emotes) > 0:
+            return emote_code in self.allowlisted_emotes
+
+        return emote_code not in self.blocklisted_emotes
+
+    @classmethod
+    def convert(cls, obj: Optional[BaseModule]) -> None:
+        if obj is None:
+            return
+
+        if obj is not CLROverlayModule:
+            raise RuntimeError("Paraneter sent to CLROverlay.convert must be a CLROverlayModule")
+
+        obj.__class__ = CLROverlayModule

--- a/pajbot/modules/clr_overlay/emotecombo.py
+++ b/pajbot/modules/clr_overlay/emotecombo.py
@@ -117,6 +117,7 @@ class EmoteComboModule(BaseModule):
         new_emote_code = new_emote.code
 
         if self.is_emote_allowed(new_emote_code) is False:
+            self.reset()
             return True
 
         # if there is currently a combo...

--- a/pajbot/modules/clr_overlay/emotecombo.py
+++ b/pajbot/modules/clr_overlay/emotecombo.py
@@ -1,15 +1,23 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, List, Optional, Set
+
 import logging
 
 from pajbot.managers.handler import HandlerManager
+from pajbot.models.emote import Emote, EmoteInstance, EmoteInstanceCountMap
 from pajbot.modules import BaseModule
 from pajbot.modules.base import ModuleSetting
 from pajbot.modules.clr_overlay import CLROverlayModule
+
+if TYPE_CHECKING:
+    from pajbot.bot import Bot
 
 log = logging.getLogger(__name__)
 
 
 class EmoteComboModule(BaseModule):
-    ID = __name__.split(".")[-1]
+    ID = __name__.rsplit(".", maxsplit=1)[-1]
     NAME = "Emote Combos"
     DESCRIPTION = "Shows emote combos on the CLR pajbot overlay"
     CATEGORY = "Feature"
@@ -23,26 +31,79 @@ class EmoteComboModule(BaseModule):
             placeholder="",
             default=5,
             constraints={"min_value": 2, "max_value": 100},
-        )
+        ),
+        ModuleSetting(
+            key="emote_allowlist",
+            label=CLROverlayModule.ALLOWLIST_LABEL,
+            type="text",
+            required=True,
+            placeholder=CLROverlayModule.EMOTELIST_PLACEHOLDER_TEXT,
+            default="",
+        ),
+        ModuleSetting(
+            key="emote_blocklist",
+            label=CLROverlayModule.BLOCKLIST_LABEL,
+            type="text",
+            required=True,
+            placeholder=CLROverlayModule.EMOTELIST_PLACEHOLDER_TEXT,
+            default="",
+        ),
     ]
 
-    def __init__(self, bot):
+    def __init__(self, bot: Optional[Bot]) -> None:
         super().__init__(bot)
-        self.emote_count = 0
-        self.current_emote = None
 
-    def inc_emote_count(self):
+        self.allowlisted_emotes: Set[str] = set()
+        self.blocklisted_emotes: Set[str] = set()
+
+        self.parent_module: Optional[CLROverlayModule] = (
+            CLROverlayModule.convert(self.bot.module_manager["clroverlay-group"]) if self.bot else None
+        )
+
+        self.emote_count: int = 0
+        self.current_emote: Optional[Emote] = None
+
+    def on_loaded(self) -> None:
+        self.allowlisted_emotes = set(
+            self.settings["emote_allowlist"].strip().split(" ") if self.settings["emote_allowlist"] else []
+        )
+        self.blocklisted_emotes = set(
+            self.settings["emote_blocklist"].strip().split(" ") if self.settings["emote_blocklist"] else []
+        )
+
+    def is_emote_allowed(self, emote_code: str) -> bool:
+        if len(self.allowlisted_emotes) > 0:
+            return emote_code in self.allowlisted_emotes
+
+        if len(self.blocklisted_emotes) > 0:
+            return emote_code not in self.blocklisted_emotes
+
+        if not self.parent_module:
+            return True
+
+        return self.parent_module.is_emote_allowed(emote_code)
+
+    def inc_emote_count(self) -> None:
+        if self.bot is None:
+            log.warning("EmoteCombo inc_emote_count called when bot is none")
+            return
+
+        assert self.current_emote is not None
+
         self.emote_count += 1
+
         if self.emote_count >= self.settings["min_emote_combo"]:
             self.bot.websocket_manager.emit(
                 "emote_combo", {"emote": self.current_emote.jsonify(), "count": self.emote_count}
             )
 
-    def reset(self):
+    def reset(self) -> None:
         self.emote_count = 0
         self.current_emote = None
 
-    def on_message(self, emote_instances, emote_counts, whisper, **rest):
+    def on_message(
+        self, emote_instances: List[EmoteInstance], emote_counts: EmoteInstanceCountMap, whisper: bool, **rest: Any
+    ) -> bool:
         if whisper:
             return True
 
@@ -54,6 +115,9 @@ class EmoteComboModule(BaseModule):
 
         new_emote = emote_instances[0].emote
         new_emote_code = new_emote.code
+
+        if self.is_emote_allowed(new_emote_code) is False:
+            return True
 
         # if there is currently a combo...
         if self.current_emote is not None:
@@ -70,8 +134,8 @@ class EmoteComboModule(BaseModule):
         self.inc_emote_count()
         return True
 
-    def enable(self, bot):
+    def enable(self, bot: Optional[Bot]) -> None:
         HandlerManager.add_handler("on_message", self.on_message)
 
-    def disable(self, bot):
+    def disable(self, bot: Optional[Bot]) -> None:
         HandlerManager.remove_handler("on_message", self.on_message)

--- a/pajbot/modules/clr_overlay/emotesonscreen.py
+++ b/pajbot/modules/clr_overlay/emotesonscreen.py
@@ -1,36 +1,28 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, List, Optional, Set
+
 import logging
 import random
 
 from pajbot.managers.handler import HandlerManager
+from pajbot.models.emote import EmoteInstance
 from pajbot.modules import BaseModule, ModuleSetting
 from pajbot.modules.clr_overlay import CLROverlayModule
+
+if TYPE_CHECKING:
+    from pajbot.bot import Bot
 
 log = logging.getLogger(__name__)
 
 
 class EmotesOnScreenModule(BaseModule):
-    ID = __name__.split(".")[-1]
+    ID = __name__.rsplit(".", maxsplit=1)[-1]
     NAME = "Emotes on Screen"
     DESCRIPTION = "Shows one or more emotes on screen per message"
     CATEGORY = "Feature"
     PARENT_MODULE = CLROverlayModule
     SETTINGS = [
-        ModuleSetting(
-            key="emote_whitelist",
-            label="Whitelisted emotes (separate by spaces). Leave empty to use the blacklist.",
-            type="text",
-            required=True,
-            placeholder="i.e. Kappa Keepo PogChamp KKona",
-            default="",
-        ),
-        ModuleSetting(
-            key="emote_blacklist",
-            label="Blacklisted emotes (separate by spaces). Leave empty to allow all emotes.",
-            type="text",
-            required=True,
-            placeholder="i.e. Kappa Keepo PogChamp KKona",
-            default="",
-        ),
         ModuleSetting(
             key="emote_opacity",
             label="Emote opacity (in percent)",
@@ -68,17 +60,61 @@ class EmotesOnScreenModule(BaseModule):
             default=100,
             constraints={"min_value": 0, "max_value": 100000},
         ),
+        ModuleSetting(
+            key="emote_whitelist",
+            label=CLROverlayModule.ALLOWLIST_LABEL,
+            type="text",
+            required=True,
+            placeholder=CLROverlayModule.EMOTELIST_PLACEHOLDER_TEXT,
+            default="",
+        ),
+        ModuleSetting(
+            key="emote_blacklist",
+            label=CLROverlayModule.BLOCKLIST_LABEL,
+            type="text",
+            required=True,
+            placeholder=CLROverlayModule.EMOTELIST_PLACEHOLDER_TEXT,
+            default="",
+        ),
     ]
 
-    def is_emote_allowed(self, emote_code):
-        if len(self.settings["emote_whitelist"].strip()) > 0:
-            return emote_code in self.settings["emote_whitelist"]
+    def __init__(self, bot: Optional[Bot]) -> None:
+        super().__init__(bot)
 
-        return emote_code not in self.settings["emote_blacklist"]
+        self.allowlisted_emotes: Set[str] = set()
+        self.blocklisted_emotes: Set[str] = set()
 
-    def on_message(self, emote_instances, whisper, **rest):
+        self.parent_module: Optional[CLROverlayModule] = (
+            CLROverlayModule.convert(self.bot.module_manager["clroverlay-group"]) if self.bot else None
+        )
+
+    def on_loaded(self) -> None:
+        self.allowlisted_emotes = set(
+            self.settings["emote_whitelist"].strip().split(" ") if self.settings["emote_whitelist"] else []
+        )
+        self.blocklisted_emotes = set(
+            self.settings["emote_blacklist"].strip().split(" ") if self.settings["emote_blacklist"] else []
+        )
+
+    def is_emote_allowed(self, emote_code: str) -> bool:
+        if len(self.allowlisted_emotes) > 0:
+            return emote_code in self.allowlisted_emotes
+
+        if len(self.blocklisted_emotes) > 0:
+            return emote_code not in self.blocklisted_emotes
+
+        if not self.parent_module:
+            return True
+
+        return self.parent_module.is_emote_allowed(emote_code)
+
+    def on_message(self, emote_instances: List[EmoteInstance], whisper: bool, **rest: Any) -> bool:
         if whisper:
-            return
+            return True
+
+        if self.bot is None:
+            log.warning("EmotesOnScreen on_message called with no bot")
+            return True
 
         # filter out disallowed emotes
         emotes = [e.emote for e in emote_instances if self.is_emote_allowed(e.emote.code)]
@@ -87,7 +123,7 @@ class EmotesOnScreenModule(BaseModule):
         sent_emotes = random.sample(emotes, sample_size)
 
         if len(sent_emotes) <= 0:
-            return
+            return True
 
         self.bot.websocket_manager.emit(
             "new_emotes",
@@ -99,8 +135,10 @@ class EmotesOnScreenModule(BaseModule):
             },
         )
 
-    def enable(self, bot):
+        return True
+
+    def enable(self, bot: Optional[Bot]) -> None:
         HandlerManager.add_handler("on_message", self.on_message)
 
-    def disable(self, bot):
+    def disable(self, bot: Optional[Bot]) -> None:
         HandlerManager.remove_handler("on_message", self.on_message)


### PR DESCRIPTION
- Split up setting & loading the ModuleManager for bot
- Move definition of EmoteInstanceCountMap to emote model
- Call `on_loaded` every time the settings are loaded or reloaded
- Add "base" settings for allowlisting and blocklisting emotes to all CLR Overlay emote modules


The CLR Overlay group module looks like this now:
![image](https://user-images.githubusercontent.com/962989/152683883-294aa9fd-6198-4145-a2be-d3d217c8c803.png)

and a child module, like the Emote Combos module, looks like this:
![image](https://user-images.githubusercontent.com/962989/152683895-80d3ccc0-e791-4f65-93ca-f2de6eda475f.png)

I think the PR is complete functionally, but some phrasing for the user might need a touchup

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

Fixes #1740

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
