### PR TITLE
Lock Jinja2 dependency to 3.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ Flask-RESTful==0.3.9
 httplib2==0.20.4
 irc==20.0.0
 isodate==0.6.1
+Jinja2==3.0.3
 jsmin==3.0.1
 Markdown==3.3.6
 psycopg2==2.9.3


### PR DESCRIPTION
3.1.x was just released which breaks our code

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
