### PR TITLE
Update menu based on module state without forcing web app restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Minor: Changed the default behaviour of certain modules showing on the navbar (pleblist, playsounds & predict) and certain statistics on the stats page (linefarming & duels). Linefarming & duels will be shown when the respective modules are enabled and cannot be overriden. Pleblist, playsounds & predictions will show on the navbar if enabled (by default, can be overriden in config) and won't show when the respective modules are disabled. (#1806)
+- Minor: Menu items are now hidden if their accompanying module is disabled (may take up to 30 seconds to refresh). This deprecates the [web] modules config option. (#1806)
+- Points menu item is now hidden if the "Loyalty" module is disabled. (#1806)
 - Minor: Add a default chat states module. This allows automation of otherwise manually triggered things; e.g. enabling emote only at the end of a stream. (#1716)
 - Minor: Added a roll module. Allowing users to roll a random number between a specified range (with timeout support). (#1722)
 - Minor: Add a global command cooldown module. This allows you to share a cooldown between selected commands. (#1714)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
+- Minor: Changed the default behaviour of certain modules showing on the navbar (pleblist, playsounds & predict) and certain statistics on the stats page (linefarming & duels). Linefarming & duels will be shown when the respective modules are enabled and cannot be overriden. Pleblist, playsounds & predictions will show on the navbar if enabled (by default, can be overriden in config) and won't show when the respective modules are disabled. (#1806)
 - Minor: Add a default chat states module. This allows automation of otherwise manually triggered things; e.g. enabling emote only at the end of a stream. (#1716)
 - Minor: Added a roll module. Allowing users to roll a random number between a specified range (with timeout support). (#1722)
 - Minor: Add a global command cooldown module. This allows you to share a cooldown between selected commands. (#1714)

--- a/configs/example.ini
+++ b/configs/example.ini
@@ -48,12 +48,13 @@ db = postgresql+psycopg2:///pajbot?options=-c%%20search_path%%3Dpajbot1_streamer
 
 [web]
 ; List of "features" you want to enable to be displayed on the website (separated by space)
+; Setting this option manually will disable the default feature - which automatically removes the entry depending on if the module is enabled or disabled.
 ; - "linefarming" adds a statistic of the top 5 chatters to the statistics page
 ; - "pleblist" adds a link to the pleblist to the top navigation bar
 ; - "playsounds" adds a link to the playsounds page to the top navigation bar
 ; - "predict" adds a link to the admin panel of the "Prediction of Arena Wins" module to the admin area.
 ; - "duels" adds a link to the duel statistics to the statistics page
-modules = linefarming duels playsounds
+;modules = linefarming duels playsounds
 ; Optionally different name of the streamer, if you don't want to/can't use their display name
 ;streamer_name = Streamer_Name
 ; domain that the website runs on

--- a/configs/example.ini
+++ b/configs/example.ini
@@ -49,12 +49,10 @@ db = postgresql+psycopg2:///pajbot?options=-c%%20search_path%%3Dpajbot1_streamer
 [web]
 ; List of "features" you want to enable to be displayed on the website (separated by space)
 ; Setting this option manually will disable the default feature - which automatically removes the entry depending on if the module is enabled or disabled.
-; - "linefarming" adds a statistic of the top 5 chatters to the statistics page
 ; - "pleblist" adds a link to the pleblist to the top navigation bar
 ; - "playsounds" adds a link to the playsounds page to the top navigation bar
 ; - "predict" adds a link to the admin panel of the "Prediction of Arena Wins" module to the admin area.
-; - "duels" adds a link to the duel statistics to the statistics page
-;modules = linefarming duels playsounds
+;modules = playsounds predict
 ; Optionally different name of the streamer, if you don't want to/can't use their display name
 ;streamer_name = Streamer_Name
 ; domain that the website runs on

--- a/configs/example.ini
+++ b/configs/example.ini
@@ -47,12 +47,6 @@ db = postgresql+psycopg2:///pajbot?options=-c%%20search_path%%3Dpajbot1_streamer
 ;safebrowsingapi = OWwcxRaHf820gei2PTouLnkUZbEWNo0EXD9cY_0
 
 [web]
-; List of "features" you want to enable to be displayed on the website (separated by space)
-; Setting this option manually will disable the default feature - which automatically removes the entry depending on if the module is enabled or disabled.
-; - "pleblist" adds a link to the pleblist to the top navigation bar
-; - "playsounds" adds a link to the playsounds page to the top navigation bar
-; - "predict" adds a link to the admin panel of the "Prediction of Arena Wins" module to the admin area.
-;modules = playsounds predict
 ; Optionally different name of the streamer, if you don't want to/can't use their display name
 ;streamer_name = Streamer_Name
 ; domain that the website runs on

--- a/pajbot/web/__init__.py
+++ b/pajbot/web/__init__.py
@@ -120,7 +120,9 @@ def init(args):
 
     SocketClientManager.init(app.streamer.login)
 
-    app.bot_modules = config["web"].get("modules", "").split()
+    if config["web"].get("modules") is not None:
+        log.warning("[web] modules config is deprecated, menu is built based on modules being enabled/disabled now")
+
     app.bot_commands_list = []
     app.bot_config = config
 
@@ -171,7 +173,6 @@ def init(args):
             "websocket": {"host": config["websocket"].get("host", f"wss://{config['web']['domain']}/clrsocket")},
         },
         "streamer": {"name": app.streamer_display, "full_name": app.streamer.login, "id": app.streamer.id},
-        "modules": app.bot_modules,
         "request": request,
         "session": session,
         "google_analytics": config["web"].get("google_analytics", None),

--- a/pajbot/web/__init__.py
+++ b/pajbot/web/__init__.py
@@ -121,7 +121,9 @@ def init(args):
     SocketClientManager.init(app.streamer.login)
 
     if config["web"].get("modules") is not None:
-        log.warning("[web] modules config is deprecated, menu is built based on modules being enabled/disabled now")
+        log.warning(
+            "DEPRECATED - [web] modules config is deprecated. Disabling options in the menu should now be done by disabling the module entirely from the Admin modules section."
+        )
 
     app.bot_commands_list = []
     app.bot_config = config

--- a/pajbot/web/common/menu.py
+++ b/pajbot/web/common/menu.py
@@ -52,10 +52,18 @@ def init(app):
     nav_bar_admin_header.append(MenuItem("/admin/timers", "admin_timers", "Timers"))
     nav_bar_admin_header.append(MenuItem("/admin/moderators", "admin_moderators", "Moderators"))
     nav_bar_admin_header.append(MenuItem("/admin/modules", "admin_modules", "Modules"))
-    if "playsounds" in app.bot_modules:
-        nav_bar_admin_header.append(MenuItem("/admin/playsounds", "admin_playsounds", "Playsounds"))
-    if "predict" in app.module_manager:
-        nav_bar_admin_header.append(MenuItem("/admin/predictions", "admin_predictions", "Predictions"))
+
+    if app.bot_modules:
+        if "playsounds" in app.bot_modules:
+            nav_bar_admin_header.append(MenuItem("/admin/playsounds", "admin_playsounds", "Playsounds"))
+        if "predict" in app.bot_modules:
+            nav_bar_admin_header.append(MenuItem("/admin/predictions", "admin_predictions", "Predictions"))
+    else:
+        if "playsound" in app.module_manager:
+            nav_bar_admin_header.append(MenuItem("/admin/playsounds", "admin_playsounds", "Playsounds"))
+        if "predict" in app.module_manager:
+            nav_bar_admin_header.append(MenuItem("/admin/predictions", "admin_predictions", "Predictions"))
+
     nav_bar_admin_header.append(MenuItem("/admin/streamer", "admin_streamer", "Streamer Info"))
 
     @app.context_processor

--- a/pajbot/web/common/menu.py
+++ b/pajbot/web/common/menu.py
@@ -29,7 +29,7 @@ def init(app):
     else:
         if "deck" in app.module_manager:
             nav_bar_header.append(MenuItem("/decks", "decks", "Decks"))
-        if "playsounds" in app.module_manager:
+        if "playsound" in app.module_manager:
             nav_bar_header.append(MenuItem("/playsounds", "user_playsounds", "Playsounds"))
         if "pleblist" in app.module_manager:
             nav_bar_header.append(MenuItem("/pleblist/history", "pleblist", "Pleblist"))

--- a/pajbot/web/common/menu.py
+++ b/pajbot/web/common/menu.py
@@ -20,7 +20,7 @@ def init(app):
     nav_bar_header.append(MenuItem("/stats", "stats", "Stats"))
 
     if app.bot_modules:
-        if "deck" in app.module_manager:
+        if "deck" in app.bot_modules:
             nav_bar_header.append(MenuItem("/decks", "decks", "Decks"))
         if "playsounds" in app.bot_modules:
             nav_bar_header.append(MenuItem("/playsounds", "user_playsounds", "Playsounds"))

--- a/pajbot/web/common/menu.py
+++ b/pajbot/web/common/menu.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Union
 
 import logging
 

--- a/pajbot/web/common/menu.py
+++ b/pajbot/web/common/menu.py
@@ -15,15 +15,24 @@ def init(app):
     nav_bar_header = []
     nav_bar_header.append(MenuItem("/", "home", "Home"))
     nav_bar_header.append(MenuItem("/commands", "commands", "Commands"))
-    if "deck" in app.module_manager:
-        nav_bar_header.append(MenuItem("/decks", "decks", "Decks"))
     if app.bot_user.login not in ["scamazbot", "exdeebot"]:
         nav_bar_header.append(MenuItem("/points", "points", "Points"))
     nav_bar_header.append(MenuItem("/stats", "stats", "Stats"))
-    if "playsounds" in app.bot_modules:
-        nav_bar_header.append(MenuItem("/playsounds", "user_playsounds", "Playsounds"))
-    if "pleblist" in app.bot_modules:
-        nav_bar_header.append(MenuItem("/pleblist/history", "pleblist", "Pleblist"))
+
+    if app.bot_modules !== "":
+        if "deck" in app.module_manager:
+            nav_bar_header.append(MenuItem("/decks", "decks", "Decks"))
+        if "playsounds" in app.bot_modules:
+            nav_bar_header.append(MenuItem("/playsounds", "user_playsounds", "Playsounds"))
+        if "pleblist" in app.bot_modules:
+            nav_bar_header.append(MenuItem("/pleblist/history", "pleblist", "Pleblist"))
+    else:
+        if "deck" in app.module_manager:
+            nav_bar_header.append(MenuItem("/decks", "decks", "Decks"))
+        if "playsounds" in app.module_manager:
+            nav_bar_header.append(MenuItem("/playsounds", "user_playsounds", "Playsounds"))
+        if "pleblist" in app.module_manager:
+            nav_bar_header.append(MenuItem("/pleblist/history", "pleblist", "Pleblist"))
 
     nav_bar_admin_header = []
     nav_bar_admin_header.append(MenuItem("/", "home", "Home"))

--- a/pajbot/web/common/menu.py
+++ b/pajbot/web/common/menu.py
@@ -68,6 +68,7 @@ def init(app):
         ]
 
         data = {
+            "enabled_modules": enabled_modules,
             "nav_bar_header": menu_items,
             "nav_bar_admin_header": admin_menu_items,
         }

--- a/pajbot/web/common/menu.py
+++ b/pajbot/web/common/menu.py
@@ -19,7 +19,7 @@ def init(app):
         nav_bar_header.append(MenuItem("/points", "points", "Points"))
     nav_bar_header.append(MenuItem("/stats", "stats", "Stats"))
 
-    if not app.bot_modules:
+    if app.bot_modules:
         if "deck" in app.module_manager:
             nav_bar_header.append(MenuItem("/decks", "decks", "Decks"))
         if "playsounds" in app.bot_modules:

--- a/pajbot/web/common/menu.py
+++ b/pajbot/web/common/menu.py
@@ -19,7 +19,7 @@ def init(app):
         nav_bar_header.append(MenuItem("/points", "points", "Points"))
     nav_bar_header.append(MenuItem("/stats", "stats", "Stats"))
 
-    if app.bot_modules !== "":
+    if not app.bot_modules:
         if "deck" in app.module_manager:
             nav_bar_header.append(MenuItem("/decks", "decks", "Decks"))
         if "playsounds" in app.bot_modules:

--- a/pajbot/web/common/menu.py
+++ b/pajbot/web/common/menu.py
@@ -1,72 +1,74 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Union
+
 import logging
+
+from pajbot.web.utils import get_cached_enabled_modules
 
 log = logging.getLogger(__name__)
 
 
 class MenuItem:
-    def __init__(self, href, menu_id, caption, level=100):
+    def __init__(
+        self,
+        href: Union[str, List[MenuItem]],
+        menu_id: str,
+        caption: str,
+        enabled: bool = True,
+        level: int = 100,
+    ) -> None:
         self.href = href
         self.id = menu_id
         self.caption = caption
+        self.enabled = enabled
         self.level = level
+        self.type = "single"
+
+        if isinstance(self.href, list):
+            self.type = "multi"
 
 
 def init(app):
-    nav_bar_header = []
-    nav_bar_header.append(MenuItem("/", "home", "Home"))
-    nav_bar_header.append(MenuItem("/commands", "commands", "Commands"))
-    if app.bot_user.login not in ["scamazbot", "exdeebot"]:
-        nav_bar_header.append(MenuItem("/points", "points", "Points"))
-    nav_bar_header.append(MenuItem("/stats", "stats", "Stats"))
-
-    if app.bot_modules:
-        if "deck" in app.bot_modules:
-            nav_bar_header.append(MenuItem("/decks", "decks", "Decks"))
-        if "playsounds" in app.bot_modules:
-            nav_bar_header.append(MenuItem("/playsounds", "user_playsounds", "Playsounds"))
-        if "pleblist" in app.bot_modules:
-            nav_bar_header.append(MenuItem("/pleblist/history", "pleblist", "Pleblist"))
-    else:
-        if "deck" in app.module_manager:
-            nav_bar_header.append(MenuItem("/decks", "decks", "Decks"))
-        if "playsound" in app.module_manager:
-            nav_bar_header.append(MenuItem("/playsounds", "user_playsounds", "Playsounds"))
-        if "pleblist" in app.module_manager:
-            nav_bar_header.append(MenuItem("/pleblist/history", "pleblist", "Pleblist"))
-
-    nav_bar_admin_header = []
-    nav_bar_admin_header.append(MenuItem("/", "home", "Home"))
-    nav_bar_admin_header.append(MenuItem("/admin", "admin_home", "Admin Home"))
-    nav_bar_admin_header.append(
-        MenuItem(
-            [
-                MenuItem("/admin/banphrases", "admin_banphrases", "Banphrases"),
-                MenuItem("/admin/links/blacklist", "admin_links_blacklist", "Blacklisted links"),
-                MenuItem("/admin/links/whitelist", "admin_links_whitelist", "Whitelisted links"),
-            ],
-            None,
-            "Filters",
-        )
-    )
-    nav_bar_admin_header.append(MenuItem("/admin/commands", "admin_commands", "Commands"))
-    nav_bar_admin_header.append(MenuItem("/admin/timers", "admin_timers", "Timers"))
-    nav_bar_admin_header.append(MenuItem("/admin/moderators", "admin_moderators", "Moderators"))
-    nav_bar_admin_header.append(MenuItem("/admin/modules", "admin_modules", "Modules"))
-
-    if app.bot_modules:
-        if "playsounds" in app.bot_modules:
-            nav_bar_admin_header.append(MenuItem("/admin/playsounds", "admin_playsounds", "Playsounds"))
-        if "predict" in app.bot_modules:
-            nav_bar_admin_header.append(MenuItem("/admin/predictions", "admin_predictions", "Predictions"))
-    else:
-        if "playsound" in app.module_manager:
-            nav_bar_admin_header.append(MenuItem("/admin/playsounds", "admin_playsounds", "Playsounds"))
-        if "predict" in app.module_manager:
-            nav_bar_admin_header.append(MenuItem("/admin/predictions", "admin_predictions", "Predictions"))
-
-    nav_bar_admin_header.append(MenuItem("/admin/streamer", "admin_streamer", "Streamer Info"))
-
     @app.context_processor
-    def menu():
-        data = {"nav_bar_header": nav_bar_header, "nav_bar_admin_header": nav_bar_admin_header}
+    def menu() -> Dict[str, Any]:
+        enabled_modules = get_cached_enabled_modules()
+
+        # Menu items that are shown for normal users
+        menu_items: List[MenuItem] = [
+            MenuItem("/", "home", "Home"),
+            MenuItem("/commands", "commands", "Commands"),
+            MenuItem("/points", "points", "Points", "chatters_refresh" in enabled_modules),
+            MenuItem("/stats", "stats", "Stats"),
+            MenuItem("/decks", "decks", "Decks", "deck" in enabled_modules),
+            MenuItem("/playsounds", "user_playsounds", "Playsounds", "playsound" in enabled_modules),
+            MenuItem("/pleblist/history", "pleblist", "Pleblist", "pleblist" in enabled_modules),
+        ]
+
+        # Menu items that are shown to admin when in an /admin page
+        admin_menu_items: List[MenuItem] = [
+            MenuItem("/", "home", "Home"),
+            MenuItem("/admin", "admin_home", "Admin Home"),
+            MenuItem(
+                [
+                    MenuItem("/admin/banphrases", "admin_banphrases", "Banphrases"),
+                    MenuItem("/admin/links/blacklist", "admin_links_blacklist", "Blacklisted links"),
+                    MenuItem("/admin/links/whitelist", "admin_links_whitelist", "Whitelisted links"),
+                ],
+                "filters",
+                "Filters",
+            ),
+            MenuItem("/admin/commands", "admin_commands", "Commands"),
+            MenuItem("/admin/timers", "admin_timers", "Timers"),
+            MenuItem("/admin/moderators", "admin_moderators", "Moderators"),
+            MenuItem("/admin/modules", "admin_modules", "Modules"),
+            MenuItem("/admin/playsounds", "admin_playsounds", "Playsounds", "playsound" in enabled_modules),
+            MenuItem("/admin/predictions", "admin_predictions", "Predictions", "predict" in enabled_modules),
+            MenuItem("/admin/streamer", "admin_streamer", "Streamer Info"),
+        ]
+
+        data = {
+            "nav_bar_header": menu_items,
+            "nav_bar_admin_header": admin_menu_items,
+        }
         return data

--- a/templates/admin/layout.html
+++ b/templates/admin/layout.html
@@ -2,9 +2,9 @@
 {% block menu %}
     <div class="ui top fixed menu inverted blue">
         <div class="menu" style="margin:auto;">
-        {% for menuitem in nav_bar_admin_header %}
+        {% for menuitem in nav_bar_admin_header if menuitem.enabled %}
         {%- if not session.user or session.user.level > menuitem.level %}
-            {%- if menuitem.id %}
+            {%- if menuitem.type == "single" %}
             <a class="inverted blue item{%- if menuitem.id == active_page %} active{% endif -%}" href="{{ menuitem.href }}">
                 {%- if menuitem.id == 'home' %}
                 <img class="logo" src="/static/images/logo_{{ streamer.full_name }}.png" alt="{{ streamer.name }} logo"/>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -26,7 +26,7 @@
 {% block menu %}
     <div class="ui top fixed menu">
         <div class="menu" style="margin:auto;">
-        {% for menuitem in nav_bar_header %}
+        {% for menuitem in nav_bar_header if menuitem.enabled %}
         <a class="item{% if menuitem.id == active_page %} active{% endif %}" href="{{ menuitem.href }}">
             {% if menuitem.id == 'home' %}
             <img class="logo" src="/static/images/logo_{{ streamer.full_name }}.png" alt="{{ streamer.name }} logo"/>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -3,7 +3,7 @@
 {% block title %}Stats{% endblock %}
 {% block body %}
 <h2>Stats</h2>
-{% if 'duels' in modules %}
+{% if 'duels' in row.db_module.enabled %}
 <p><a href="/stats/duels/"><i class="icon linkify"></i>  Duel stats</a></p>
 {% endif %}
 <h3><a href="https://stats.streamelements.com/c/{{ streamer.full_name }}">StreamElements stats page</a></h3>
@@ -24,7 +24,7 @@
                 </tr>
             {% endfor %}
     </table>
-    {% if 'linefarming' in modules %}
+    {% if 'linefarming' in row.db_module.enabled %}
         <h3>Top 5 Line Farmers</h3>
         <table class="ui very basic table">
             <thead>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -3,7 +3,7 @@
 {% block title %}Stats{% endblock %}
 {% block body %}
 <h2>Stats</h2>
-{% if 'duels' in row.db_module.enabled %}
+{% if 'duel' in enabled_modules %}
 <p><a href="/stats/duels/"><i class="icon linkify"></i>  Duel stats</a></p>
 {% endif %}
 <h3><a href="https://stats.streamelements.com/c/{{ streamer.full_name }}">StreamElements stats page</a></h3>
@@ -24,7 +24,7 @@
                 </tr>
             {% endfor %}
     </table>
-    {% if 'linefarming' in row.db_module.enabled %}
+    {% if 'linefarming' in enabled_modules %}
         <h3>Top 5 Line Farmers</h3>
         <table class="ui very basic table">
             <thead>


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

I didn't want to have to manually define this, so I've added an option to just omit the modules config entry altogether.