### PR TITLE
Fix banphrase API not properly returning matching banphrase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Security: Add integrity checks to javascript resources loaded from external CDNs. (#1813)
 - Major: Remove pleblist API endpoints. (#1809)
 - Major: Remove pleblist pages. (#1809)
+- Bugfix: Fix banphrase API not properly returning matching banphrase. (#1823)
 - Dev: Migrate from `flask_restful` to `marshmallow` for handling request parameter parsing. (#1809)
 
 ## v1.60

--- a/pajbot/web/routes/api/banphrases.py
+++ b/pajbot/web/routes/api/banphrases.py
@@ -104,7 +104,7 @@ def init(bp: Blueprint) -> None:
 
         if res is not False:
             ret["banned"] = True
-            ret["banphrase_data"] = res
+            ret["banphrase_data"] = res.jsonify()
 
         return ret
 


### PR DESCRIPTION
- Fix banphrase API not properly returning matching banphrase
- Add changelog entry



Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
