### PR TITLE
Command response type now sticks properly when a command is edited through chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Major: Full deletion of pleblist module; excluding table-related code. (#1814)
 - Major: Remove pleblist API endpoints. (#1809)
 - Major: Remove pleblist pages. (#1809)
+- Bugfix: Command response type now sticks properly when a command is edited through chat. (#1846)
 - Bugfix: Fix toggling of submodules. (#1824)
 - Bugfix: Fix banphrase API not properly returning matching banphrase. (#1823)
 - Bugfix: Fix toggling of playsound module from the playsound admin page. (#1825)

--- a/pajbot/managers/command.py
+++ b/pajbot/managers/command.py
@@ -429,10 +429,12 @@ class CommandManager(UserDict):
         message: str,
     ) -> Tuple[Union[Dict[str, Any], Literal[False]], Union[str, Literal[False]]]:
         parser = argparse.ArgumentParser()
-        parser.add_argument("--whisper", dest="whisper", action="store_true")
-        parser.add_argument("--no-whisper", dest="whisper", action="store_false")
-        parser.add_argument("--reply", dest="reply", action="store_true")
-        parser.add_argument("--no-reply", dest="reply", action="store_false")
+
+        # Update action type/response type
+        parser.add_argument("--whisper", dest="action_type", action="store_const", const="whisper", default=None)
+        parser.add_argument("--reply", dest="action_type", action="store_const", const="reply", default=None)
+        parser.add_argument("--say", dest="action_type", action="store_const", const="say", default=None)
+
         parser.add_argument("--cd", type=int, dest="delay_all")
         parser.add_argument("--usercd", type=int, dest="delay_user")
         parser.add_argument("--level", type=int, dest="level")
@@ -467,5 +469,9 @@ class CommandManager(UserDict):
             options["cost"] = abs(options["cost"])
         if "tokens_cost" in options:
             options["tokens_cost"] = abs(options["tokens_cost"])
+
+        if response.startswith(".me ") or response.startswith("/me "):
+            options["action_type"] = "me"
+            response = " ".join(response.split(" ")[1:])
 
         return options, response


### PR DESCRIPTION
Edit command now preserves the command response type unless explicitly set

To set a command response type as a whisper, use --whisper
To set a command response type as a reply, use --reply
To set a command response type as an action, prefix the message with `.me` or `/me`
To set a command response type as to say (default), use --say

Fixes #1838




Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
