### PR TITLE
Workaround for vip_refresh failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Bugfix: Fix toggling of playsound module from the playsound admin page. (#1825)
 - Bugfix: Fix errors in the API not properly returning a JSON response. (#1833)
 - Bugfix: Fix command "Check message" option not being modifiable. (#1845)
+- Bugfix: Work around no VIPs being refreshed through VIP refresh module in some cases. (#1862)
 - Dev: Migrate from `flask_restful` to `marshmallow` for handling request parameter parsing. (#1809)
 
 ## v1.60

--- a/pajbot/modules/vip_refresh.py
+++ b/pajbot/modules/vip_refresh.py
@@ -27,7 +27,7 @@ class VIPRefreshModule(BaseModule):
     UPDATE_INTERVAL = 10  # minutes
 
     # This regex matches login names but not display names if they contain any non-ascii characters or spaces
-    LOGIN_REGEX = re.compile(r"^[a-z0-9](?:\w{1,24})?$", re.IGNORECASE)
+    LOGIN_REGEX = re.compile(r"^[a-z0-9]\w{0,24}$", re.IGNORECASE)
 
     def __init__(self, bot):
         super().__init__(bot)

--- a/pajbot/modules/vip_refresh.py
+++ b/pajbot/modules/vip_refresh.py
@@ -40,7 +40,7 @@ class VIPRefreshModule(BaseModule):
         self.bot.privmsg("/vips")
 
     @staticmethod
-    def _parse_pubnotice_for_vips(self, msg_id, message):
+    def _parse_pubnotice_for_vips(msg_id, message):
         if msg_id == "no_vips":
             return []
 
@@ -68,7 +68,7 @@ class VIPRefreshModule(BaseModule):
         if channel != self.bot.streamer.login:
             return
 
-        vip_logins = self._parse_pubnotice_for_vips(self, msg_id, message)
+        vip_logins = self._parse_pubnotice_for_vips(msg_id, message)
 
         if vip_logins is not None:
             self.bot.action_queue.submit(self._process_vip_logins, vip_logins)

--- a/pajbot/modules/vip_refresh.py
+++ b/pajbot/modules/vip_refresh.py
@@ -39,7 +39,7 @@ class VIPRefreshModule(BaseModule):
         self.bot.privmsg("/vips")
 
     @staticmethod
-    def _parse_pubnotice_for_vips(msg_id, message):
+    def _parse_pubnotice_for_vips(self, msg_id, message):
         if msg_id == "no_vips":
             return []
 

--- a/pajbot/modules/vip_refresh.py
+++ b/pajbot/modules/vip_refresh.py
@@ -67,7 +67,7 @@ class VIPRefreshModule(BaseModule):
         if channel != self.bot.streamer.login:
             return
 
-        vip_logins = self._parse_pubnotice_for_vips(msg_id, message)
+        vip_logins = self._parse_pubnotice_for_vips(self, msg_id, message)
 
         if vip_logins is not None:
             self.bot.action_queue.submit(self._process_vip_logins, vip_logins)

--- a/pajbot/modules/vip_refresh.py
+++ b/pajbot/modules/vip_refresh.py
@@ -24,6 +24,7 @@ class VIPRefreshModule(BaseModule):
 
     UPDATE_INTERVAL = 10  # minutes
 
+    # This regex matches login names but not display names if they contain any non-ascii characters or spaces
     LOGIN_REGEX = re.compile(r"^[a-z0-9](?:\w{1,24})?$", re.IGNORECASE)
 
     def __init__(self, bot):

--- a/pajbot/modules/vip_refresh.py
+++ b/pajbot/modules/vip_refresh.py
@@ -24,7 +24,7 @@ class VIPRefreshModule(BaseModule):
 
     UPDATE_INTERVAL = 10  # minutes
 
-    USERNAME_REGEX = re.compile(r"^[a-z0-9](?:\w{1,24})?$", re.IGNORECASE)
+    LOGIN_REGEX = re.compile(r"^[a-z0-9](?:\w{1,24})?$", re.IGNORECASE)
 
     def __init__(self, bot):
         super().__init__(bot)
@@ -50,7 +50,7 @@ class VIPRefreshModule(BaseModule):
                 vips = message.split(", ")
                 # Response of "vips_success" returns display names, which could contain non-ascii characters.
                 # For now, we filter these out since these cannot be resolved through helix, see https://github.com/pajbot/pajbot/issues/1772
-                filtered_vips = [vip for vip in vips if re.match(VIPRefreshModule.USERNAME_REGEX, vip)]
+                filtered_vips = [vip for vip in vips if re.match(VIPRefreshModule.LOGIN_REGEX, vip)]
                 if len(vips) != len(filtered_vips):
                     log.warning("Some non-ascii display names were filtered out from vips_success NOTICE response.")
                 return filtered_vips

--- a/pajbot/modules/vip_refresh.py
+++ b/pajbot/modules/vip_refresh.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import logging
 import re
 
@@ -41,6 +43,10 @@ class VIPRefreshModule(BaseModule):
         self.bot.privmsg("/vips")
 
     @staticmethod
+    def _filter_vips(vips: List[str]) -> List[str]:
+        return [vip for vip in vips if re.match(VIPRefreshModule.LOGIN_REGEX, vip)]
+
+    @staticmethod
     def _parse_pubnotice_for_vips(msg_id, message):
         if msg_id == "no_vips":
             return []
@@ -51,7 +57,7 @@ class VIPRefreshModule(BaseModule):
                 vips = message.split(", ")
                 # Response of "vips_success" returns display names, which could contain non-ascii characters.
                 # For now, we filter these out since these cannot be resolved through helix, see https://github.com/pajbot/pajbot/issues/1772
-                filtered_vips = [vip for vip in vips if re.match(VIPRefreshModule.LOGIN_REGEX, vip)]
+                filtered_vips = VIPRefreshModule._filter_vips(vips)
                 if len(vips) != len(filtered_vips):
                     log.warning("Some non-ascii display names were filtered out from vips_success NOTICE response.")
                 return filtered_vips

--- a/pajbot/modules/vip_refresh.py
+++ b/pajbot/modules/vip_refresh.py
@@ -24,10 +24,11 @@ class VIPRefreshModule(BaseModule):
 
     UPDATE_INTERVAL = 10  # minutes
 
+    USERNAME_REGEX = re.compile(r"^[a-z0-9](?:\w{1,24})?$", re.IGNORECASE)
+
     def __init__(self, bot):
         super().__init__(bot)
         self.scheduled_job = None
-        self.username_regex = re.compile(r"^[a-z0-9](?:\w{1,24})?$", re.IGNORECASE)
 
     def update_vip_cmd(self, bot, source, **rest):
         # TODO if you wanted to improve this: Provide the user with feedback
@@ -49,7 +50,7 @@ class VIPRefreshModule(BaseModule):
                 vips = message.split(", ")
                 # Response of "vips_success" returns display names, which could contain non-ascii characters.
                 # For now, we filter these out since these cannot be resolved through helix, see https://github.com/pajbot/pajbot/issues/1772
-                filtered_vips = [vip for vip in vips if re.match(self.username_regex, vip)]
+                filtered_vips = [vip for vip in vips if re.match(VIPRefreshModule.USERNAME_REGEX, vip)]
                 if len(vips) != len(filtered_vips):
                     log.warning("Some non-ascii display names were filtered out from vips_success NOTICE response.")
                 return filtered_vips

--- a/pajbot/modules/vip_refresh.py
+++ b/pajbot/modules/vip_refresh.py
@@ -27,7 +27,7 @@ class VIPRefreshModule(BaseModule):
     def __init__(self, bot):
         super().__init__(bot)
         self.scheduled_job = None
-        self.username_regex = re.compile("^[a-zA-Z0-9](?:\w{1,24})?$")
+        self.username_regex = re.compile(r"^[a-z0-9](?:\w{1,24})?$", re.IGNORECASE)
 
     def update_vip_cmd(self, bot, source, **rest):
         # TODO if you wanted to improve this: Provide the user with feedback

--- a/pajbot/modules/vip_refresh.py
+++ b/pajbot/modules/vip_refresh.py
@@ -49,7 +49,7 @@ class VIPRefreshModule(BaseModule):
                 vips = message.split(", ")
                 # Response of "vips_success" returns display names, which could contain non-ascii characters.
                 # For now, we filter these out since these cannot be resolved through helix, see https://github.com/pajbot/pajbot/issues/1772
-                filtered_vips = [vip for vip in vips if re.match(username_regex, vip)]
+                filtered_vips = [vip for vip in vips if re.match(self.username_regex, vip)]
                 if len(vips) != len(filtered_vips):
                     log.warning("Some non-ascii display names were filtered out from vips_success NOTICE response.")
                 return filtered_vips

--- a/pajbot/tests/modules/test_filter_vips.py
+++ b/pajbot/tests/modules/test_filter_vips.py
@@ -1,34 +1,28 @@
 from typing import List, Tuple
 
-import pytest
-
 from pajbot.modules.vip_refresh import VIPRefreshModule
+
+import pytest
 
 
 def get_filter_vips_cases() -> List[Tuple[List[str], List[str]]]:
     return [
-            # Standard login names
-            (["foo"], ["foo"]),
-            (["pajlada", "forsen"], ["pajlada", "forsen"]),
-
-            # Display names where they're ascii-only but contain uppercase characters
-            (["pajlada", "FORSEN"], ["pajlada", "FORSEN"]),
-
-            # Display names with spaces in the middle should be filtered out
-            (["pajlada", "Riot Games", "forsen"], ["pajlada", "forsen"]),
-
-            # Display names with spaces at the end should be filtered out
-            (["pajlada", "testman ", "forsen"], ["pajlada", "forsen"]),
-
-            # Display names with spaces at the start should be filtered out
-            (["pajlada", " testman", "forsen"], ["pajlada", "forsen"]),
-
-            # Display names non-ascii characters should be filtered out
-            (["pajlada", "테스트계정420", "forsen"], ["pajlada", "forsen"]),
-
-            # Empty list
-            ([], []),
-            ]
+        # Standard login names
+        (["foo"], ["foo"]),
+        (["pajlada", "forsen"], ["pajlada", "forsen"]),
+        # Display names where they're ascii-only but contain uppercase characters
+        (["pajlada", "FORSEN"], ["pajlada", "FORSEN"]),
+        # Display names with spaces in the middle should be filtered out
+        (["pajlada", "Riot Games", "forsen"], ["pajlada", "forsen"]),
+        # Display names with spaces at the end should be filtered out
+        (["pajlada", "testman ", "forsen"], ["pajlada", "forsen"]),
+        # Display names with spaces at the start should be filtered out
+        (["pajlada", " testman", "forsen"], ["pajlada", "forsen"]),
+        # Display names non-ascii characters should be filtered out
+        (["pajlada", "테스트계정420", "forsen"], ["pajlada", "forsen"]),
+        # Empty list
+        ([], []),
+    ]
 
 
 @pytest.mark.parametrize("input_vips,expected_vips", get_filter_vips_cases())

--- a/pajbot/tests/modules/test_filter_vips.py
+++ b/pajbot/tests/modules/test_filter_vips.py
@@ -9,6 +9,7 @@ def get_filter_vips_cases() -> List[Tuple[List[str], List[str]]]:
     return [
         # Standard login names
         (["foo"], ["foo"]),
+        (["Pajlada"], ["Pajlada"]),
         (["pajlada", "forsen"], ["pajlada", "forsen"]),
         # Display names where they're ascii-only but contain uppercase characters
         (["pajlada", "FORSEN"], ["pajlada", "FORSEN"]),
@@ -20,6 +21,10 @@ def get_filter_vips_cases() -> List[Tuple[List[str], List[str]]]:
         (["pajlada", " testman", "forsen"], ["pajlada", "forsen"]),
         # Display names non-ascii characters should be filtered out
         (["pajlada", "테스트계정420", "forsen"], ["pajlada", "forsen"]),
+        # Names cannot start with _
+        # Names can contain _ just not at the start
+        (["_pajlada"], []),
+        (["pajlada_"], ["pajlada_"]),
         # Empty list
         ([], []),
     ]

--- a/pajbot/tests/modules/test_filter_vips.py
+++ b/pajbot/tests/modules/test_filter_vips.py
@@ -1,0 +1,36 @@
+from typing import List, Tuple
+
+import pytest
+
+from pajbot.modules.vip_refresh import VIPRefreshModule
+
+
+def get_filter_vips_cases() -> List[Tuple[List[str], List[str]]]:
+    return [
+            # Standard login names
+            (["foo"], ["foo"]),
+            (["pajlada", "forsen"], ["pajlada", "forsen"]),
+
+            # Display names where they're ascii-only but contain uppercase characters
+            (["pajlada", "FORSEN"], ["pajlada", "FORSEN"]),
+
+            # Display names with spaces in the middle should be filtered out
+            (["pajlada", "Riot Games", "forsen"], ["pajlada", "forsen"]),
+
+            # Display names with spaces at the end should be filtered out
+            (["pajlada", "testman ", "forsen"], ["pajlada", "forsen"]),
+
+            # Display names with spaces at the start should be filtered out
+            (["pajlada", " testman", "forsen"], ["pajlada", "forsen"]),
+
+            # Display names non-ascii characters should be filtered out
+            (["pajlada", "테스트계정420", "forsen"], ["pajlada", "forsen"]),
+
+            # Empty list
+            ([], []),
+            ]
+
+
+@pytest.mark.parametrize("input_vips,expected_vips", get_filter_vips_cases())
+def test_filter_vips(input_vips: List[str], expected_vips: List[str]) -> None:
+    assert VIPRefreshModule._filter_vips(input_vips) == expected_vips


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

As described throughtly in GH-1772, `vips_success` NOTICE returns display names, which could contain non-ascii characters - these special names make Helix whole helix request fail and that is what I'm trying to avoid here.

Closes: GH-1772