### PR TITLE
Update `me` method in `send_message_to_user` function to include user ping

### DIFF
--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -715,7 +715,7 @@ class Bot:
         elif method == "whisper":
             self.whisper(user, message)
         elif method == "me":
-            self.me(message)
+            self.me(f"@{user.name}, {message}")
         elif method == "reply":
             if event.type in ["action", "pubmsg"]:
                 msg_id = next(tag["value"] for tag in event.tags if tag["key"] == "id")


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [ ] I have tested all changes

Currently the me method in the `send_message_to_user` function is completely useless. It doesn't do anything on top of the method in the `send_message` and requires extra arguments. Given the defining part between both functions is sending the message TO THE USER, we should ping the user in the me method (same as the say method).