### PR TITLE
Add more tests to models/action.py substitution parsing

### DIFF
--- a/pajbot/models/action.py
+++ b/pajbot/models/action.py
@@ -339,7 +339,9 @@ def get_substitution_arguments(sub_key):
     return sub_string, path, argument, key, filters, if_arguments
 
 
-def get_substitutions(string: str, bot: Bot) -> Dict[str, Substitution]:
+def get_substitutions(
+    string: str, bot: Optional[Bot], method_mapping: Optional[Dict[str, Callable[..., Any]]] = None
+) -> Dict[str, Substitution]:
     """
     Returns a dictionary of `Substitution` objects that are are found in the passed `string`.
     Will not return multiple `Substitution` objects for the same string.
@@ -366,35 +368,37 @@ def get_substitutions(string: str, bot: Bot) -> Dict[str, Substitution]:
         except:
             log.exception("BabyRage")
 
-    method_mapping: Dict[str, Callable[..., Any]] = {}
-    try:
-        method_mapping["kvi"] = bot.get_kvi_value
-        method_mapping["tb"] = bot.get_value
-        method_mapping["lasttweet"] = bot.get_last_tweet
-        # "etm" is legacy
-        method_mapping["etm"] = bot.get_emote_epm
-        method_mapping["epm"] = bot.get_emote_epm
-        method_mapping["etmrecord"] = bot.get_emote_epm_record
-        method_mapping["epmrecord"] = bot.get_emote_epm_record
-        method_mapping["ecount"] = bot.get_emote_count
-        method_mapping["source"] = bot.get_source_value
-        method_mapping["user"] = bot.get_user_value
-        method_mapping["usersource"] = bot.get_usersource_value
-        method_mapping["time"] = bot.get_time_value
-        method_mapping["date"] = bot.get_date_value
-        method_mapping["datetimefromisoformat"] = bot.get_datetimefromisoformat_value
-        method_mapping["datetimefromtimestamp"] = bot.get_datetimefromtimestamp_value
-        method_mapping["datetime"] = bot.get_datetime_value
-        method_mapping["curdeck"] = bot.decks.action_get_curdeck
-        method_mapping["stream"] = bot.stream_manager.get_stream_value
-        method_mapping["current_stream"] = bot.stream_manager.get_current_stream_value
-        method_mapping["last_stream"] = bot.stream_manager.get_last_stream_value
-        method_mapping["args"] = bot.get_args_value
-        method_mapping["strictargs"] = bot.get_strictargs_value
-        method_mapping["command"] = bot.get_command_value
-        method_mapping["broadcaster"] = bot.get_broadcaster_value
-    except AttributeError:
-        pass
+    if method_mapping is None:
+        method_mapping = {}
+        try:
+            if bot:
+                method_mapping["kvi"] = bot.get_kvi_value
+                method_mapping["tb"] = bot.get_value
+                method_mapping["lasttweet"] = bot.get_last_tweet
+                # "etm" is legacy
+                method_mapping["etm"] = bot.get_emote_epm
+                method_mapping["epm"] = bot.get_emote_epm
+                method_mapping["etmrecord"] = bot.get_emote_epm_record
+                method_mapping["epmrecord"] = bot.get_emote_epm_record
+                method_mapping["ecount"] = bot.get_emote_count
+                method_mapping["source"] = bot.get_source_value
+                method_mapping["user"] = bot.get_user_value
+                method_mapping["usersource"] = bot.get_usersource_value
+                method_mapping["time"] = bot.get_time_value
+                method_mapping["date"] = bot.get_date_value
+                method_mapping["datetimefromisoformat"] = bot.get_datetimefromisoformat_value
+                method_mapping["datetimefromtimestamp"] = bot.get_datetimefromtimestamp_value
+                method_mapping["datetime"] = bot.get_datetime_value
+                method_mapping["curdeck"] = bot.decks.action_get_curdeck
+                method_mapping["stream"] = bot.stream_manager.get_stream_value
+                method_mapping["current_stream"] = bot.stream_manager.get_current_stream_value
+                method_mapping["last_stream"] = bot.stream_manager.get_last_stream_value
+                method_mapping["args"] = bot.get_args_value
+                method_mapping["strictargs"] = bot.get_strictargs_value
+                method_mapping["command"] = bot.get_command_value
+                method_mapping["broadcaster"] = bot.get_broadcaster_value
+        except AttributeError:
+            pass
 
     for sub_key in Substitution.substitution_regex.finditer(string):
         sub_string, path, argument, key, filters, if_arguments = get_substitution_arguments(sub_key)


### PR DESCRIPTION
To make get_substitutions easier to test, it allows the sender to pass
through its own custom method mapping dictionary



Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
