### PR TITLE
Added `/announce` to the list of permitted twitch commands

### DIFF
--- a/pajbot/utils/clean_up_message.py
+++ b/pajbot/utils/clean_up_message.py
@@ -1,7 +1,10 @@
 from typing import Optional
 
 # list of twitch commands permitted, without leading slash or dot
-permitted_commands = {"me"}
+permitted_commands = {
+    "me",
+    "announce",
+}
 
 
 def clean_up_message(message: str) -> str:


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

This makes it so commands starting with `/announce` can go through.
However maybe this is not the way to fix the issue - in case there's a `!shuffle` or `!say` command I could see this being abused. A completely safe solution would be to pass a boolean `allowAnnounce` parameter to `utils.clean_up_message` which would be true only when `bot.announce` invokes `bot.say`. Or maybe this is something we shouldn't bother about.
