### PR TITLE
Fix playsounds sometimes not being editable from the admin panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 
 - Breaking: Removed fatoverlay and crazyoverlay. These were alternatives to `/clr/overlay/<number>`, e.g. `/clr/fatoverlay/<number>`. If you don't know what these are, or if you never used these, then this will not affect you. (#1946)
 - Bugfix: Fix `announce` message type for commands and timers. (#1955)
+- Bugfix: Fix playsounds sometimes not being settable. (#1972)
 
 ## v1.61
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 
 - Breaking: Removed fatoverlay and crazyoverlay. These were alternatives to `/clr/overlay/<number>`, e.g. `/clr/fatoverlay/<number>`. If you don't know what these are, or if you never used these, then this will not affect you. (#1946)
 - Bugfix: Fix `announce` message type for commands and timers. (#1955)
-- Bugfix: Fix playsounds sometimes not being settable. (#1972)
+- Bugfix: Fix playsounds sometimes not being editable from the admin panel. (#1972)
 
 ## v1.61
 

--- a/templates/admin/playsounds.html
+++ b/templates/admin/playsounds.html
@@ -157,7 +157,7 @@
                 </td>
                 <td class="top aligned">
                     <div class="min-height-container volume-container">
-                        <input form="form-{{ playsound.name }}" type="hidden" name="volume">
+                        <input form="form-{{ playsound.name }}" type="hidden" name="volume" value="{{ playsound.volume }}">
                         <div class="ui slider volume-slider" data-initial="{{ playsound.volume }}"></div>
                         <div class="volume-label">{{ playsound.volume }}</div>
                     </div>


### PR DESCRIPTION
- Initialize form default value for playsounds
- Add changelog entry



Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

Fixes #1971

This happened because the volume form input wasn't initially set

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
