### PR TITLE
Filters in commands are now applied even if the result of a substitution returns an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
 - Breaking: Removed fatoverlay and crazyoverlay. These were alternatives to `/clr/overlay/<number>`, e.g. `/clr/fatoverlay/<number>`. If you don't know what these are, or if you never used these, then this will not affect you. (#1946)
+- Major: Potentially breaking, filters in commands are now applied even if the result of a substitution returns an error. (#1973)  
+  This makes all `or_...` filters a lot more useful, but it may mean that some other filters will need some additional error handling.  
+  This will require some experimentation, reporting errors in our GitHub issues for this is greatly appreciated.
 - Bugfix: Fix `announce` message type for commands and timers. (#1955)
 - Bugfix: Fix playsounds sometimes not being editable from the admin panel. (#1972)
 

--- a/pajbot/models/action.py
+++ b/pajbot/models/action.py
@@ -711,8 +711,6 @@ def apply_substitutions(text, substitutions: Dict[Any, Substitution], bot: Bot, 
         # The dictionary of substitutions here will always come from get_substitutions, which means it will always have a callback to call
         assert sub.cb is not None
         value: Any = sub.cb(param, extra)
-        if value is None:
-            return None
         try:
             for f in sub.filters:
                 value = bot.apply_filter(value, f)


### PR DESCRIPTION
- Filters are now applied even if the result of a substitution is None
- Add changelog entry

Fixes #1966

This makes all `or_...` filters a lot more useful, but it may mean that
some other filters will need some additional error handling.

I think the tradeoff is worth it, and that we can take care of errors
with other filters as they come up.

How to test:
`!edit command foof a $(user;1:username|or_broadcaster) b`
Before fix:
`!foof` - no reply
`!foof forsen` - reply "a forsen b"

After fix:
`!foof` - reply "a STREAMER b"
`!foof forsen` - reply "a forsen b"


Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
