### PR TITLE
Fix missing `--announce` command argument for changing the reply type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 
 - Breaking: Removed fatoverlay and crazyoverlay. These were alternatives to `/clr/overlay/<number>`, e.g. `/clr/fatoverlay/<number>`. If you don't know what these are, or if you never used these, then this will not affect you. (#1946)
 - Bugfix: Fix `announce` message type for commands and timers. (#1955)
+- Bugfix: Fix missing `--announce` command argument for changing the reply type. (#1974)
 - Bugfix: Fix playsounds sometimes not being editable from the admin panel. (#1972)
 
 ## v1.61

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -16,6 +16,7 @@
 
 `--whisper`/`--no-whisper` - whispers the response of the command. Default = no-whisper  
 `--reply`/`--no-reply` - context-dependant reply based on where the command is used. Default = no-reply  
+`--announce`/`--no-announce` - sets the command to use the announce reply type (i.e. Twitch's /announce feature)  
 `--cd` - sets the global cooldown of the command (in seconds). Default = 5 seconds  
 `--usercd` - sets the per-user cooldown of the command (in seconds). Default = 15 seconds  
 `--level` - sets the required level to use the command. If the mod-only argument is used, the mod must also meet the level specified here in order to use the command. Default = 100  

--- a/pajbot/managers/command.py
+++ b/pajbot/managers/command.py
@@ -434,6 +434,7 @@ class CommandManager(UserDict):
         parser.add_argument("--whisper", dest="action_type", action="store_const", const="whisper", default=None)
         parser.add_argument("--reply", dest="action_type", action="store_const", const="reply", default=None)
         parser.add_argument("--say", dest="action_type", action="store_const", const="say", default=None)
+        parser.add_argument("--announce", dest="action_type", action="store_const", const="announce", default=None)
 
         parser.add_argument("--cd", type=int, dest="delay_all")
         parser.add_argument("--usercd", type=int, dest="delay_user")


### PR DESCRIPTION
This was missing since the `announce` message type was added in #1847



Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
