### PR TITLE
Use get_phrase in lastfm module example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Minor: Migrated LastFM module to the `reply` response type. (#2118)
+- Minor: Migrated LastFM module to the `reply` response type. (#2118, #2128)
 
 ## v1.62
 

--- a/pajbot/modules/lastfm.py
+++ b/pajbot/modules/lastfm.py
@@ -83,6 +83,7 @@ class LastfmModule(BaseModule):
     def load_commands(self, **options):
         # TODO: Aliases should be set in settings?
         #       This way, it can be run alongside other modules
+        example_params = {"streamer": StreamHelper.get_streamer(), "song": "Adele - Hello"}
         self.commands["song"] = Command.raw_command(
             self.song,
             delay_all=self.settings["global_cd"],
@@ -92,8 +93,7 @@ class LastfmModule(BaseModule):
                 CommandExample(
                     None,
                     "Check the current song",
-                    chat="user:!song\n"
-                    f"bot: @pajlada {self.settings['current_song'].format(streamer=StreamHelper.get_streamer(), song='Adele - Hello')}",
+                    chat="user:!song\n" f"bot: @pajlada {self.get_phrase('current_song', **example_params)}",
                     description="Bot mentions the name of the song and the artist currently playing on stream",
                 ).parse()
             ],


### PR DESCRIPTION
We removed the source parameter so this is required to get old bots to restart properly

Without this change, if a user had `{source}` as part of their message, the bot would crashloop.
Using `get_phrase` now instead of raw `format`, we'll get an warning message in the bot and it will fall back to the default phrase.

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
