### PR TITLE
Migrate bans from IRC to Helix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ For your bot to work after these changes, the bot owner **must** re-authenticate
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Breaking: Migrated banning function from IRC to Helix.
+- Breaking: Migrated banning function from IRC to Helix. (#2213)
 - Breaking: Migrated VIP Refresh module from IRC to Helix. (#2188)
 - Breaking: Migrated Moderator Refresh module from IRC to Helix. (#2186, #2202)
 - Breaking: Migrated Sub Mode function from IRC to Helix. (#2185)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For your bot to work after these changes, the bot owner **must** re-authenticate
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
+- Breaking: Migrated banning function from IRC to Helix.
 - Breaking: Migrated VIP Refresh module from IRC to Helix. (#2188)
 - Breaking: Migrated Moderator Refresh module from IRC to Helix. (#2186, #2202)
 - Breaking: Migrated Sub Mode function from IRC to Helix. (#2185)

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -758,3 +758,26 @@ class TwitchHelixAPI(BaseTwitchAPI):
         vips = self._fetch_all_pages(self._fetch_vips_page, broadcaster_id, authorization)
 
         return set(vips)
+
+    def _ban_user(
+        self,
+        broadcaster_id: str,
+        bot_id: str,
+        authorization,
+        duration: Optional[int] = None,
+        reason: str = None,
+        user_id: str = None,
+    ) -> Tuple[str, Optional[str]]:
+        """Calls the Ban User Helix endpoint using the broadcaster_id, bot_id, reason & user_id parameters.
+        broadcaster_id, bot_id, reason & user_id are all required parameters. bot_id must match the user_id in authorization."""
+        response = self.post(
+            "/moderation/bans",
+            {"broadcaster_id": broadcaster_id, "moderator_id": bot_id},
+            authorization=authorization,
+            json={"duration": duration, "reason": reason, "user_id": user_id},
+        )
+
+        created_at = response["data"][0]["created_at"]
+        end_time = response["data"][0]["end_time"]
+
+        return created_at, end_time

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -781,3 +781,10 @@ class TwitchHelixAPI(BaseTwitchAPI):
         end_time = response["data"][0]["end_time"]
 
         return created_at, end_time
+
+    def ban_user(self, broadcaster_id: str, bot_id: str, authorization, reason: str, user_id: str) -> str:
+        """Calls the _ban_user function using the reason & user_id parameters.
+        All fields are required. bot_id must match the user_id in authorization."""
+        response = self._ban_user(broadcaster_id, bot_id, authorization, reason, user_id)
+
+        return response[0]

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -773,7 +773,7 @@ class TwitchHelixAPI(BaseTwitchAPI):
             "/moderation/bans",
             {"broadcaster_id": broadcaster_id, "moderator_id": bot_id},
             authorization=authorization,
-            json={"reason": reason, "user_id": user_id},
+            json={"data": {"reason": reason, "user_id": user_id}},
         )
 
         created_at = response["data"][0]["created_at"]

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -759,13 +759,12 @@ class TwitchHelixAPI(BaseTwitchAPI):
 
         return set(vips)
 
-    def _ban_user(
+    def ban_user(
         self,
         broadcaster_id: str,
         bot_id: str,
         authorization,
         user_id: str,
-        duration: Optional[int] = None,
         reason: Optional[str] = None,
     ) -> Tuple[str, Optional[str]]:
         """Calls the Ban User Helix endpoint using the broadcaster_id, bot_id, reason & user_id parameters.
@@ -774,19 +773,10 @@ class TwitchHelixAPI(BaseTwitchAPI):
             "/moderation/bans",
             {"broadcaster_id": broadcaster_id, "moderator_id": bot_id},
             authorization=authorization,
-            json={"duration": duration, "reason": reason, "user_id": user_id},
+            json={"reason": reason, "user_id": user_id},
         )
 
         created_at = response["data"][0]["created_at"]
         end_time = response["data"][0]["end_time"]
 
         return created_at, end_time
-
-    def ban_user(
-        self, broadcaster_id: str, bot_id: str, authorization, user_id: str, reason: Optional[str] = None
-    ) -> str:
-        """Calls the _ban_user function using the reason & user_id parameters.
-        All fields are required. bot_id must match the user_id in authorization."""
-        response = self._ban_user(broadcaster_id, bot_id, authorization, user_id, reason)
-
-        return response[0]

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -766,7 +766,7 @@ class TwitchHelixAPI(BaseTwitchAPI):
         authorization,
         user_id: str,
         duration: Optional[int] = None,
-        reason: str = None,
+        reason: Optional[str] = None,
     ) -> Tuple[str, Optional[str]]:
         """Calls the Ban User Helix endpoint using the broadcaster_id, bot_id, reason & user_id parameters.
         broadcaster_id, bot_id, reason & user_id are all required parameters. bot_id must match the user_id in authorization."""
@@ -782,7 +782,7 @@ class TwitchHelixAPI(BaseTwitchAPI):
 
         return created_at, end_time
 
-    def ban_user(self, broadcaster_id: str, bot_id: str, authorization, reason: str, user_id: str) -> str:
+    def ban_user(self, broadcaster_id: str, bot_id: str, authorization, user_id: str, reason: Optional[str] = None) -> str:
         """Calls the _ban_user function using the reason & user_id parameters.
         All fields are required. bot_id must match the user_id in authorization."""
         response = self._ban_user(broadcaster_id, bot_id, authorization, user_id, reason)

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -782,7 +782,9 @@ class TwitchHelixAPI(BaseTwitchAPI):
 
         return created_at, end_time
 
-    def ban_user(self, broadcaster_id: str, bot_id: str, authorization, user_id: str, reason: Optional[str] = None) -> str:
+    def ban_user(
+        self, broadcaster_id: str, bot_id: str, authorization, user_id: str, reason: Optional[str] = None
+    ) -> str:
         """Calls the _ban_user function using the reason & user_id parameters.
         All fields are required. bot_id must match the user_id in authorization."""
         response = self._ban_user(broadcaster_id, bot_id, authorization, user_id, reason)

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -764,9 +764,9 @@ class TwitchHelixAPI(BaseTwitchAPI):
         broadcaster_id: str,
         bot_id: str,
         authorization,
+        user_id: str,
         duration: Optional[int] = None,
         reason: str = None,
-        user_id: str = None,
     ) -> Tuple[str, Optional[str]]:
         """Calls the Ban User Helix endpoint using the broadcaster_id, bot_id, reason & user_id parameters.
         broadcaster_id, bot_id, reason & user_id are all required parameters. bot_id must match the user_id in authorization."""
@@ -785,6 +785,6 @@ class TwitchHelixAPI(BaseTwitchAPI):
     def ban_user(self, broadcaster_id: str, bot_id: str, authorization, reason: str, user_id: str) -> str:
         """Calls the _ban_user function using the reason & user_id parameters.
         All fields are required. bot_id must match the user_id in authorization."""
-        response = self._ban_user(broadcaster_id, bot_id, authorization, reason, user_id)
+        response = self._ban_user(broadcaster_id, bot_id, authorization, user_id, reason)
 
         return response[0]

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -649,6 +649,8 @@ class Bot:
 
     def ban(self, user: User, reason: Optional[str] = None) -> None:
         self.ban_login(user.login, reason)
+    def ban_id(self, userid: str, reason=None) -> None:
+        self._ban(userid, reason)
 
     def ban_login(self, login: str, reason=None) -> None:
         userid = self.twitch_helix_api.get_user_id(login)

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -1025,7 +1025,7 @@ class Bot:
 
         if self.streamer == "forsen":
             if "zonothene" in login:
-                self._ban(login)
+                self.ban_id(id)
                 return True
 
             raw_m = event.arguments[0].lower()

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -648,7 +648,8 @@ class Bot:
                 log.error(f"Failed to ban user with id {userid}: {e} - {e.response.text}")
 
     def ban(self, user: User, reason: Optional[str] = None) -> None:
-        self.ban_login(user.login, reason)
+        self.ban_id(user.id, reason)
+
     def ban_id(self, userid: str, reason=None) -> None:
         self._ban(userid, reason)
 

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -650,10 +650,10 @@ class Bot:
     def ban(self, user: User, reason: Optional[str] = None) -> None:
         self.ban_id(user.id, reason)
 
-    def ban_id(self, user_id: str, reason=None) -> None:
+    def ban_id(self, user_id: str, reason: Optional[str] = None) -> None:
         self._ban(user_id, reason)
 
-    def ban_login(self, login: str, reason=None) -> None:
+    def ban_login(self, login: str, reason: Optional[str] = None) -> None:
         user_id = self.twitch_helix_api.get_user_id(login)
         if self._has_moderation_actions():
             self.thread_locals.moderation_actions.add(login, Ban(reason))

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -640,7 +640,7 @@ class Bot:
 
     def _ban(self, userid: str, reason: Optional[str] = None) -> None:
         try:
-            self.twitch_helix_api.ban_user(self.streamer.id, self.bot_user.id, self.bot_token_manager, reason, userid)
+            self.twitch_helix_api.ban_user(self.streamer.id, self.bot_user.id, self.bot_token_manager, userid, reason)
         except HTTPError as e:
             if e.response.status_code == 401:
                 log.error(f"Failed to ban user with id {userid}, unauthorized: {e} - {e.response.text}")

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -638,28 +638,28 @@ class Bot:
             return False
         return self.thread_locals.moderation_actions is not None
 
-    def _ban(self, userid: str, reason: Optional[str] = None) -> None:
+    def _ban(self, user_id: str, reason: Optional[str] = None) -> None:
         try:
-            self.twitch_helix_api.ban_user(self.streamer.id, self.bot_user.id, self.bot_token_manager, userid, reason)
+            self.twitch_helix_api.ban_user(self.streamer.id, self.bot_user.id, self.bot_token_manager, user_id, reason)
         except HTTPError as e:
             if e.response.status_code == 401:
-                log.error(f"Failed to ban user with id {userid}, unauthorized: {e} - {e.response.text}")
+                log.error(f"Failed to ban user with id {user_id}, unauthorized: {e} - {e.response.text}")
             else:
-                log.error(f"Failed to ban user with id {userid}: {e} - {e.response.text}")
+                log.error(f"Failed to ban user with id {user_id}: {e} - {e.response.text}")
 
     def ban(self, user: User, reason: Optional[str] = None) -> None:
         self.ban_id(user.id, reason)
 
-    def ban_id(self, userid: str, reason=None) -> None:
-        self._ban(userid, reason)
+    def ban_id(self, user_id: str, reason=None) -> None:
+        self._ban(user_id, reason)
 
     def ban_login(self, login: str, reason=None) -> None:
-        userid = self.twitch_helix_api.get_user_id(login)
+        user_id = self.twitch_helix_api.get_user_id(login)
         if self._has_moderation_actions():
             self.thread_locals.moderation_actions.add(login, Ban(reason))
         else:
             self.timeout_login(login, 30, reason, once=True)
-            self.execute_delayed(1, self.ban_id, userid, reason)
+            self.execute_delayed(1, self.ban_id, user_id, reason)
 
     def unban(self, user: User) -> None:
         self.unban_login(user.login)

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -659,7 +659,7 @@ class Bot:
             self.thread_locals.moderation_actions.add(login, Ban(reason))
         else:
             self.timeout_login(login, 30, reason, once=True)
-            self.execute_delayed(1, self._ban, login, reason)
+            self.execute_delayed(1, self.ban_id, userid, reason)
 
     def unban(self, user: User) -> None:
         self.unban_login(user.login)

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -1025,7 +1025,7 @@ class Bot:
 
         if self.streamer == "forsen":
             if "zonothene" in login:
-                self.ban_id(id)
+                self._ban(id)
                 return True
 
             raw_m = event.arguments[0].lower()

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -638,11 +638,14 @@ class Bot:
             return False
         return self.thread_locals.moderation_actions is not None
 
-    def _ban(self, login: str, reason: Optional[str] = None) -> None:
-        message = f"/ban {login}"
-        if reason is not None:
-            message += f" {reason}"
-        self.privmsg(message)
+    def _ban(self, userid: str, reason: Optional[str] = None) -> None:
+        try:
+            self.twitch_helix_api.ban_user(self.streamer.id, self.bot_user.id, self.bot_token_manager, reason, userid)
+        except HTTPError as e:
+            if e.response.status_code == 401:
+                log.error(f"Failed to ban user with id {userid}, unauthorized: {e} - {e.response.text}")
+            else:
+                log.error(f"Failed to ban user with id {userid}: {e} - {e.response.text}")
 
     def ban(self, user: User, reason: Optional[str] = None) -> None:
         self.ban_login(user.login, reason)

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -648,6 +648,7 @@ class Bot:
         self.ban_login(user.login, reason)
 
     def ban_login(self, login: str, reason=None) -> None:
+        userid = self.twitch_helix_api.get_user_id(login)
         if self._has_moderation_actions():
             self.thread_locals.moderation_actions.add(login, Ban(reason))
         else:

--- a/pajbot/models/banphrase.py
+++ b/pajbot/models/banphrase.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional, Union, Literal, Tuple
+from typing import TYPE_CHECKING, List, Literal, Optional, Tuple, Union
 
 import argparse
 import logging


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

In an effort to maintain compatibility with existing functions, I have:

- Added a `ban_id` function
- Updated `ban` function to utilize `ban_id`
- Updated `ban_login` to get the `userid` of the user being banned

Despite previous conversations, I have chosen NOT to migrate the moderation actions to user IDs yet; else I may break other functions in the process. I think we should work on migrating the functions first to helix, then migrate to user IDs after all the moderation endpoints have been migrated.

Note that I also kept the existing `ban_login` function so we don't break any existing functions that people might have.