### PR TITLE
Migrate untimeouts from IRC to Helix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ For your bot to work after these changes, the bot owner **must** re-authenticate
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Breaking: Migrated untimeout function from IRC to Helix.
+- Breaking: Migrated untimeout function from IRC to Helix. (#2223)
 - Breaking: Migrated banning function from IRC to Helix. (#2213)
 - Breaking: Migrated VIP Refresh module from IRC to Helix. (#2188)
 - Breaking: Migrated Moderator Refresh module from IRC to Helix. (#2186, #2202)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For your bot to work after these changes, the bot owner **must** re-authenticate
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
+- Breaking: Migrated untimeout function from IRC to Helix.
 - Breaking: Migrated banning function from IRC to Helix. (#2213)
 - Breaking: Migrated VIP Refresh module from IRC to Helix. (#2188)
 - Breaking: Migrated Moderator Refresh module from IRC to Helix. (#2186, #2202)

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -889,6 +889,6 @@ class TwitchHelixAPI(BaseTwitchAPI):
     def get_banned_user(self, broadcaster_id: str, authorization, user_id: str) -> Optional[TwitchBannedUser]:
         """Calls the _get_banned_users function using the broadcaster_id and user_id parameter.
         All parameters are required and broadcaster_id must match the user ID in authorization."""
-        response, cursor = self._get_banned_users(broadcaster_id, authorization, user_id)
+        response, _ = self._get_banned_users(broadcaster_id, authorization, user_id)
 
         return response[0] if len(response) > 0 else None

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -768,7 +768,7 @@ class TwitchHelixAPI(BaseTwitchAPI):
         reason: Optional[str] = None,
     ) -> Tuple[str, Optional[str]]:
         """Calls the Ban User Helix endpoint using the broadcaster_id, bot_id, reason & user_id parameters.
-        broadcaster_id, bot_id, reason & user_id are all required parameters. bot_id must match the user_id in authorization."""
+        broadcaster_id, bot_id & user_id are all required parameters. bot_id must match the user_id in authorization."""
         response = self.post(
             "/moderation/bans",
             {"broadcaster_id": broadcaster_id, "moderator_id": bot_id},

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -886,7 +886,7 @@ class TwitchHelixAPI(BaseTwitchAPI):
 
         return users, pagination_cursor
 
-    def get_single_banned_user(self, broadcaster_id: str, authorization, user_id: str) -> Optional[TwitchBannedUser]:
+    def get_banned_user(self, broadcaster_id: str, authorization, user_id: str) -> Optional[TwitchBannedUser]:
         """Calls the _get_banned_users function using the broadcaster_id and user_id parameter.
         All parameters are required and broadcaster_id must match the user ID in authorization."""
         response, cursor = self._get_banned_users(broadcaster_id, authorization, user_id)

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -780,3 +780,21 @@ class TwitchHelixAPI(BaseTwitchAPI):
         end_time = response["data"][0]["end_time"]
 
         return created_at, end_time
+
+    def untimeout_user(
+        self,
+        broadcaster_id: str,
+        bot_id: str,
+        authorization,
+        user_id: str,
+        reason: str = "Untimeout",
+    ) -> None:
+        """Calls the Ban User Helix endpoint using the broadcaster_id, bot_id, reason & user_id parameters.
+        broadcaster_id, bot_id & user_id are all required parameters. bot_id must match the user_id in authorization.
+        The default reason is set as 'Untimeout' in order to distinguish between a normal timeout and an untimeout."""
+        self.post(
+            "/moderation/bans",
+            {"broadcaster_id": broadcaster_id, "moderator_id": bot_id},
+            authorization=authorization,
+            json={"data": {"reason": reason, "user_id": user_id, "duration": 1}},
+        )

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -51,6 +51,57 @@ class TwitchGame:
         )
 
 
+class TwitchBannedUser:
+    def __init__(
+        self,
+        user_id: str,
+        user_login: str,
+        user_name: str,
+        created_at: str,
+        expires_at: str,
+        reason: str,
+        moderator_id: str,
+        moderator_login: str,
+        moderator_name: str,
+    ):
+        self.user_id = user_id
+        self.user_login = user_login
+        self.user_name = user_name
+        self.created_at = created_at
+        self.expires_at = expires_at
+        self.reason = reason
+        self.moderator_id = moderator_id
+        self.moderator_login = moderator_login
+        self.moderator_name = moderator_name
+
+    def jsonify(self):
+        return {
+            "user_id": self.user_id,
+            "user_login": self.user_login,
+            "user_name": self.user_name,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+            "reason": self.reason,
+            "moderator_id": self.moderator_id,
+            "moderator_login": self.moderator_login,
+            "moderator_name": self.moderator_name,
+        }
+
+    @staticmethod
+    def from_json(json_data):
+        return TwitchBannedUser(
+            json_data["user_id"],
+            json_data["user_login"],
+            json_data["user_name"],
+            json_data["created_at"],
+            json_data["expires_at"],
+            json_data["reason"],
+            json_data["moderator_id"],
+            json_data["moderator_login"],
+            json_data["moderator_name"],
+        )
+
+
 class TwitchVideo:
     def __init__(
         self,
@@ -816,7 +867,7 @@ class TwitchHelixAPI(BaseTwitchAPI):
         authorization,
         user_id: Optional[str] = None,
         after_pagination_cursor: Optional[str] = None,
-    ):
+    ) -> Tuple[List[TwitchBannedUser], Optional[str]]:
         """Calls the Get Banned Users Helix endpoint using the broadcaster_id & user_id parameter.
         broadcaster_id is a required field and must match the user ID in authorization."""
         response = self.get(
@@ -830,13 +881,14 @@ class TwitchHelixAPI(BaseTwitchAPI):
             authorization=authorization,
         )
 
+        users = [TwitchBannedUser.from_json(data) for data in response["data"]]
         pagination_cursor = response["pagination"].get("cursor", None)
 
-        return response["data"], pagination_cursor
+        return users, pagination_cursor
 
-    def get_single_banned_user(self, broadcaster_id: str, authorization, user_id: str) -> str:
+    def get_single_banned_user(self, broadcaster_id: str, authorization, user_id: str) -> Optional[TwitchBannedUser]:
         """Calls the _get_banned_users function using the broadcaster_id and user_id parameter.
         All parameters are required and broadcaster_id must match the user ID in authorization."""
-        response = self._get_banned_users(broadcaster_id, authorization, user_id)
+        response, cursor = self._get_banned_users(broadcaster_id, authorization, user_id)
 
-        return response["expires_at"]
+        return response[0] if len(response) > 0 else None

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -656,7 +656,7 @@ class Bot:
     def ban_login(self, login: str, reason: Optional[str] = None) -> None:
         user_id = self.twitch_helix_api.get_user_id(login)
         if user_id is None:
-            log.error(f"Attempted to unban user with login {login}, but no such user was found")
+            log.error(f"Attempted to ban user with login {login}, but no such user was found")
             return
 
         if self._has_moderation_actions():
@@ -725,7 +725,7 @@ class Bot:
     def untimeout_login(self, login: str) -> None:
         user_id = self.twitch_helix_api.get_user_id(login)
         if user_id is None:
-            log.error(f"Attempted to unban user with login {login}, but no such user was found")
+            log.error(f"Attempted to untimeout user with login {login}, but no such user was found")
             return
 
         if self._has_moderation_actions():

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -655,6 +655,10 @@ class Bot:
 
     def ban_login(self, login: str, reason: Optional[str] = None) -> None:
         user_id = self.twitch_helix_api.get_user_id(login)
+        if user_id is None:
+            log.error(f"Attempted to unban user with login {login}, but no such user was found")
+            return
+
         if self._has_moderation_actions():
             self.thread_locals.moderation_actions.add(login, Ban(reason))
         else:
@@ -687,6 +691,10 @@ class Bot:
 
     def untimeout_login(self, login: str) -> None:
         user_id = self.twitch_helix_api.get_user_id(login)
+        if user_id is None:
+            log.error(f"Attempted to unban user with login {login}, but no such user was found")
+            return
+
         if self._has_moderation_actions():
             self.thread_locals.moderation_actions.add(login, Untimeout())
         else:

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -686,10 +686,11 @@ class Bot:
         self._untimeout(user_id)
 
     def untimeout_login(self, login: str) -> None:
+        user_id = self.twitch_helix_api.get_user_id(login)
         if self._has_moderation_actions():
             self.thread_locals.moderation_actions.add(login, Untimeout())
         else:
-            self.privmsg(f"/untimeout {login}")
+            self.untimeout_id(user_id)
 
     def _timeout(self, login: str, duration: int, reason: Optional[str] = None) -> None:
         message = f"/timeout {login} {duration}"

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -682,6 +682,9 @@ class Bot:
     def untimeout(self, user: User) -> None:
         self.untimeout_login(user.login)
 
+    def untimeout_id(self, user_id: str) -> None:
+        self._untimeout(user_id)
+
     def untimeout_login(self, login: str) -> None:
         if self._has_moderation_actions():
             self.thread_locals.moderation_actions.add(login, Untimeout())

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -693,7 +693,7 @@ class Bot:
 
     def _untimeout(self, user_id: str) -> None:
         try:
-            ban_data = self.twitch_helix_api.get_single_banned_user(
+            ban_data = self.twitch_helix_api.get_banned_user(
                 self.streamer.id, self.streamer_access_token_manager, user_id
             )
             if ban_data is None:

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -680,7 +680,7 @@ class Bot:
                 log.error(f"Failed to untimeout user with id {user_id}: {e} - {e.response.text}")
 
     def untimeout(self, user: User) -> None:
-        self.untimeout_login(user.login)
+        self.untimeout_id(user.id)
 
     def untimeout_id(self, user_id: str) -> None:
         self._untimeout(user_id)

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -670,6 +670,15 @@ class Bot:
         else:
             self.privmsg(f"/unban {login}")
 
+    def _untimeout(self, user_id: str) -> None:
+        try:
+            self.twitch_helix_api.untimeout_user(self.streamer.id, self.bot_user.id, self.bot_token_manager, user_id)
+        except HTTPError as e:
+            if e.response.status_code == 401:
+                log.error(f"Failed to untimeout user with id {user_id}, unauthorized: {e} - {e.response.text}")
+            else:
+                log.error(f"Failed to untimeout user with id {user_id}: {e} - {e.response.text}")
+
     def untimeout(self, user: User) -> None:
         self.untimeout_login(user.login)
 

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -693,11 +693,14 @@ class Bot:
 
     def _untimeout(self, user_id: str) -> None:
         try:
-            is_banned = self.twitch_helix_api.get_single_banned_user(
+            ban_data = self.twitch_helix_api.get_single_banned_user(
                 self.streamer.id, self.streamer_access_token_manager, user_id
             )
+            if ban_data is None:
+                log.warning(f"User with ID {user_id} is already not banned or timed-out.")
+                return
             # As per the Helix docs, expires_at will return empty if the user is permabanned.
-            if is_banned is not None:
+            if not ban_data.expires_at:
                 log.error(f"User with ID {user_id} is currently banned! Will not untimeout.")
                 return
         except HTTPError as e:


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

I have modified the code to be more consistent with the ban functions:

- Added an `untimeout_id` function
- Added an `_untimeout` function
- Updated `untimeout` function to utilize `untimeout_id`
- Updated `untimeout_login` to get the `user_id` of the user being banned.

I kept the existing `untimeout_login` function as to not break anyone else's existing code that utilizes this function.