### PR TITLE
fix(helix): only consider subs with names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Breaking: Migrated Unique Chat function from IRC to Helix. (#2177)
 - Breaking: Migrated Announce from IRC to Helix. (#2141)
 - Breaking: Migrated Delete moderation action from IRC to Helix. (#2173)
+- Bugfix: Exclude deleted accounts from twitch subscribers list. (#2292)
 - Bugfix: Fix bot not correctly tracking online/offline state of stream due to TwitchGame not being deserialized properly. (#2243)
 - Minor: Updated `Wide Emote Limit` module to account for wide BTTV emotes (##2272)
 - Minor: Migrated LastFM module to the `reply` response type. (#2118, #2128)

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -349,7 +349,9 @@ class TwitchHelixAPI(BaseTwitchAPI):
         # }
 
         subscribers = [
-            UserBasics(entry["user_id"], entry["user_login"], entry["user_name"]) for entry in response["data"] if entry["user_login"]
+            UserBasics(entry["user_id"], entry["user_login"], entry["user_name"])
+            for entry in response["data"]
+            if entry["user_login"]
         ]
         pagination_cursor = response["pagination"].get("cursor", None)
 

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -351,7 +351,9 @@ class TwitchHelixAPI(BaseTwitchAPI):
         subscribers = [
             UserBasics(entry["user_id"], entry["user_login"], entry["user_name"])
             for entry in response["data"]
-            if entry["user_login"]
+
+            # deleted users can appear with empty name https://github.com/twitchdev/issues/issues/717
+            if entry["user_login"] is not None and entry["user_login"] != ""
         ]
         pagination_cursor = response["pagination"].get("cursor", None)
 

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -351,7 +351,6 @@ class TwitchHelixAPI(BaseTwitchAPI):
         subscribers = [
             UserBasics(entry["user_id"], entry["user_login"], entry["user_name"])
             for entry in response["data"]
-
             # deleted users can appear with empty name https://github.com/twitchdev/issues/issues/717
             if entry["user_login"] is not None and entry["user_login"] != ""
         ]

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -349,7 +349,7 @@ class TwitchHelixAPI(BaseTwitchAPI):
         # }
 
         subscribers = [
-            UserBasics(entry["user_id"], entry["user_login"], entry["user_name"]) for entry in response["data"]
+            UserBasics(entry["user_id"], entry["user_login"], entry["user_name"]) for entry in response["data"] if entry["user_login"]
         ]
         pagination_cursor = response["pagination"].get("cursor", None)
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] I have tested all changes

Works around issue where helix subscriptions api can yield user_id's that correspond to deleted accounts (so the name is empty)

![image](https://user-images.githubusercontent.com/8106344/215239402-0cc53e86-df57-4a4c-910a-4997eceffd85.png)

Related: https://github.com/twitchdev/issues/issues/717
