### PR TITLE
Migrate timeouts to Helix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For your bot to work after these changes, the bot owner **must** re-authenticate
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
 - Breaking: Migrated whispers from IRC to Helix. Note that this will require you to add a phone number to the Bot account for whispers to continue working. (#2317)
+- Breaking: Migrated timeouts from IRC to Helix. (#2318)
 - Breaking: Migrated Follower Only function from IRC to Helix. (#2175)
 - Breaking: Migrated untimeout function from IRC to Helix. (#2223)
 - Breaking: Migrated unbanning function from IRC to Helix. (#2222)

--- a/pajbot/apiwrappers/twitch/helix.py
+++ b/pajbot/apiwrappers/twitch/helix.py
@@ -865,6 +865,31 @@ class TwitchHelixAPI(BaseTwitchAPI):
 
         return created_at, end_time
 
+    def timeout_user(
+        self,
+        broadcaster_id: str,
+        bot_id: str,
+        authorization,
+        user_id: str,
+        duration: int,
+        reason: Optional[str] = None,
+    ) -> Tuple[str, Optional[str]]:
+        """Calls the Ban User Helix endpoint using the broadcaster_id, bot_id, reason & user_id parameters.
+        broadcaster_id, bot_id & user_id are all required parameters. bot_id must match the user_id in authorization.
+        duration is in seconds
+        """
+        response = self.post(
+            "/moderation/bans",
+            {"broadcaster_id": broadcaster_id, "moderator_id": bot_id},
+            authorization=authorization,
+            json={"data": {"reason": reason, "user_id": user_id, "duration": duration}},
+        )
+
+        created_at = response["data"][0]["created_at"]
+        end_time = response["data"][0]["end_time"]
+
+        return created_at, end_time
+
     def unban_user(
         self,
         broadcaster_id: str,

--- a/pajbot/models/moderation_action.py
+++ b/pajbot/models/moderation_action.py
@@ -22,7 +22,6 @@ class Unban:
 class Timeout:
     duration: int
     reason: Optional[str]
-    once: bool
 
 
 @dataclass
@@ -81,7 +80,6 @@ class ModerationActions:
                 self.actions[login] = Timeout(
                     duration=max(action.duration, existing_action.duration),
                     reason=_combine_reasons(existing_action.reason, action.reason),
-                    once=existing_action.once and action.once,
                 )
             else:
                 # timeout wins over lower-tier action
@@ -113,7 +111,7 @@ class ModerationActions:
             if isinstance(action, Ban):
                 bot.ban_login(login, action.reason)
             if isinstance(action, Timeout):
-                bot.timeout_login(login, action.duration, action.reason, action.once)
+                bot.timeout_login(login, action.duration, action.reason)
             if isinstance(action, Unban):
                 bot.unban_login(login)
             if isinstance(action, Untimeout):

--- a/pajbot/modules/basic/selftimeout.py
+++ b/pajbot/modules/basic/selftimeout.py
@@ -170,6 +170,6 @@ class SelfTimeoutModule(BaseModule):
             # Check if timeout value is over Twitch's maximum
             timeout_length = min(timeout_length, 1209600)
 
-            bot.timeout(source, timeout_length, f"{standard_response}!", once=True)
+            bot.timeout(source, timeout_length, f"{standard_response}!")
 
         return True

--- a/pajbot/modules/massping.py
+++ b/pajbot/modules/massping.py
@@ -193,7 +193,6 @@ class MassPingProtectionModule(BaseModule):
             timeout_duration,
             self.settings["timeout_reason"],
             disable_warnings=self.settings["disable_warnings"],
-            once=True,
         )
         return False
 


### PR DESCRIPTION
- Remove `once` for timeouts
- Migrate timeouts to Helix

NOTE: This is inefficient, it converts full user objects to logins only to be converted to IDs again.

There is no clean solution without making all of `moderation_actions` deal with IDs, which is not something I want to do in the same PR.

Fixes #2156 


Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
