### PR TITLE
Add setting to control how frequently user ranks should be refreshed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Minor: Migrated LastFM module to the `reply` response type. (#2118, #2128)
 - Minor: Increased efficiency and speed of subscriber status refresh. (#2203)
 - Minor: Install documentation now recommends the use of limited-scope CloudFlare API tokens. (#2201)
+- Minor: Add setting to control how frequently user ranks should be refreshed. (#2320)
 - Dev: Migrated to 7TV's new REST API. (#2268)
 
 ## v1.62

--- a/configs/example.ini
+++ b/configs/example.ini
@@ -49,7 +49,7 @@ db = postgresql+psycopg2:///pajbot?options=-c%%20search_path%%3Dpajbot1_streamer
 ; Optional section if you want to configure how user ranks are refreshed
 ; 0 (default) = refresh every 5 minutes or so
 ; 1 = refresh once on startup only
-; 2 = never refresh
+; 2 = never refresh (Be wary of setting this on a completely new bot)
 ;rank_refresh_mode = 0
 
 [web]

--- a/configs/example.ini
+++ b/configs/example.ini
@@ -46,6 +46,12 @@ db = postgresql+psycopg2:///pajbot?options=-c%%20search_path%%3Dpajbot1_streamer
 ; See https://developers.google.com/safe-browsing/v4/get-started for how to get such an API Key
 ;safebrowsingapi = OWwcxRaHf820gei2PTouLnkUZbEWNo0EXD9cY_0
 
+; Optional section if you want to configure how user ranks are refreshed
+; 0 (default) = refresh every 5 minutes or so
+; 1 = refresh once on startup only
+; 2 = never refresh
+;rank_refresh_mode = 0
+
 [web]
 ; Optionally different name of the streamer, if you don't want to/can't use their display name
 ;streamer_name = Streamer_Name

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -185,7 +185,16 @@ class Bot:
         self.action_queue = ActionQueue()
 
         # refresh points_rank and num_lines_rank regularly
-        UserRanksRefreshManager.start(self.action_queue)
+
+        rank_refresh_mode = config["main"].get("rank_refresh_mode", "0")
+        if rank_refresh_mode == "0":
+            UserRanksRefreshManager.start(self.action_queue)
+        elif rank_refresh_mode == "1":
+            UserRanksRefreshManager.run_once(self.action_queue)
+        elif rank_refresh_mode == "2":
+            log.info("Not refreshing user rank")
+        else:
+            log.error(f"Invalid rank refresh mode {rank_refresh_mode}, valid options are: 0, 1, or 2")
 
         self.reactor = irc.client.Reactor()
         # SafeDefaultScheduler makes the bot not exit on exception in the main thread


### PR DESCRIPTION
Under the `main` section, set the `rank_refresh_mode` to:
0 (default) = refresh every 5 minutes or so
1 = refresh once on startup only
2 = never refresh


Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
