### PR TITLE
Fix moderator refresh throwing errors if the API errors out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Bugfix: Exclude deleted accounts from twitch subscribers list. (#2292)
 - Bugfix: Fix bot not correctly tracking online/offline state of stream due to TwitchGame not being deserialized properly. (#2243)
 - Bugfix: Exclude deleted accounts from Twitch VIP & Moderators lists, and try to handle empty usernames better in other places. (#2319)
+- Bugfix: Fix bot not handling missing streamer token when trying to refresh moderators. (#2324)
 - Minor: Updated `Wide Emote Limit` module to account for wide BTTV emotes (##2272)
 - Minor: Migrated LastFM module to the `reply` response type. (#2118, #2128)
 - Minor: Increased efficiency and speed of subscriber status refresh. (#2203)
@@ -32,6 +33,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Dev: Migrated to 7TV's new REST API. (#2268)
 - Dev: Add a bunch of typing related to `on_message`/`on_pubmsg` & command actions. (#2321)
 - Dev: Add typing to all quest modules. (#2322)
+- Dev: Add typing to the ModeratorsRefresh module. (#2324)
 
 ## v1.62
 

--- a/pajbot/modules/moderators_refresh.py
+++ b/pajbot/modules/moderators_refresh.py
@@ -6,7 +6,7 @@ import logging
 
 from pajbot.apiwrappers.authentication.token_manager import NoTokenError
 from pajbot.managers.db import DBManager
-from pajbot.managers.schedule import ScheduleManager, ScheduledJob
+from pajbot.managers.schedule import ScheduledJob, ScheduleManager
 from pajbot.models.command import Command, CommandExample
 from pajbot.models.user import User
 from pajbot.modules.base import BaseModule, ModuleType

--- a/pajbot/modules/moderators_refresh.py
+++ b/pajbot/modules/moderators_refresh.py
@@ -68,9 +68,10 @@ class ModeratorsRefreshModule(BaseModule):
                 log.error(
                     "Cannot fetch moderators because no streamer token is present. Have the streamer login with the /streamer_login web route to enable moderator fetch."
                 )
-                return
             else:
                 log.error(f"Failed to update moderators: {e} - {e.response.text}")
+
+            return
 
         with DBManager.create_session_scope() as db_session:
             db_session.execute(


### PR DESCRIPTION
- Add typing to the ModeratorsRefresh module
- Add changelog entry
- reformat imports
- Fix bot not handling missing streamer token when trying to refresh moderators



Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
