### PR TITLE
Add the option to hide timestamps from the logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 - Minor: Install documentation now recommends the use of limited-scope CloudFlare API tokens. (#2201)
 - Minor: Add setting to control how frequently user ranks should be refreshed. (#2320)
 - Minor: Update variable documentation to clarify how (not) to use `tb:user` and `tb:source`. (#2333)
+- Dev: Add the option to hide timestamp in log entries using the `PB1_LOG_HIDE_TIMESTAMPS` environment variable. (#2334)
 - Dev: Migrated to 7TV's new REST API. (#2268)
 - Dev: Add a bunch of typing related to `on_message`/`on_pubmsg` & command actions. (#2321)
 - Dev: Add typing to all quest modules. (#2322)

--- a/README.md
+++ b/README.md
@@ -18,3 +18,11 @@ Current minimal supported Python version is **3.8**.
 ## Detailed install
 
 You can find a detailed installation guide for **pajbot** in the [`install-docs` directory](./install-docs) of this repository.
+
+## Run-time options
+
+Some values can be set to apply to your bot without modifying the config file, these are mostly for out-of-bot things.  
+They are configured using environment variables. The following options are available:
+
+- `PB1_LOG_HIDE_TIMESTAMPS`  
+   If this option is set to `1`, all log entries will be printed without a timestamp prefix.

--- a/pajbot/utils/init_logging.py
+++ b/pajbot/utils/init_logging.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 
 from colorama import Fore, Style
@@ -36,7 +37,15 @@ def init_logging(app: str = "pajbot") -> logging.Logger:
     logger = logging.getLogger(app)
     logger.setLevel(logging.DEBUG)
 
-    colored_formatter = ColoredFormatter("[%(asctime)s] [%(levelname)-20s] %(message)s")
+    hide_timestamps = os.getenv("PB1_LOG_HIDE_TIMESTAMPS", "0") == "1"
+
+    colored_formatter: ColoredFormatter
+
+    if hide_timestamps:
+        colored_formatter = ColoredFormatter("[%(levelname)-20s] %(message)s")
+    else:
+        colored_formatter = ColoredFormatter("[%(asctime)s] [%(levelname)-20s] %(message)s")
+
     log_filter = LogFilter(logging.WARNING)
 
     logger_stdout = logging.StreamHandler(sys.stdout)


### PR DESCRIPTION


Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

# Description

This can be done setting the `PB1_LOG_HIDE_TIMESTAMPS` environment variable to `1`
If the environment variable is not set, timestamps will be shown like normal

# How I tested it

I tested this by not setting the environment variable: Timestamps are shown as expected
I tested this by setting the environment variable to `1`: Timestamps are hidden as expected
I tested this by setting the environment variable to `0`: Timestamps are shown as expected
I tested this by setting the environment variable to `forsen`: Timestamps are shown as expected (invalid value).

I could technically make it accept things like "true" or "yes" or "on" but I think keeping it simple & consistent with `config.ini` to just be `0` or `1` is alright


# Why I want this functionality

I run my bots through systemd, and I use journalctl for logging which adds its own timestamp, so logs become a bit longer than necessary (see `Feb 18 22:21:30 scadrial pajbot-post-helix@pajlada[1911870]: [2023-02-18 22:21:30,036] [INFO   ] Successfully updated 36 VIPs`)

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
