### PR TITLE
Remove ratelimiter dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unversioned
 
+- Dev: Remove `ratelimiter` dependency, it was used to rate limit IRC connection creations which is not necessary any longer. (#2340)
+
 ## v1.63
 
 Due to Twitch deprecating most IRC commands, we are now migrating to the equivalent Helix calls.

--- a/pajbot/managers/irc.py
+++ b/pajbot/managers/irc.py
@@ -10,7 +10,6 @@ from pajbot.managers.schedule import ScheduledJob, ScheduleManager
 
 from irc.client import InvalidCharacters, MessageTooLong, ServerConnection, ServerNotConnectedError
 from irc.connection import Factory
-from ratelimiter import RateLimiter
 
 if TYPE_CHECKING:
     from pajbot.bot import Bot
@@ -68,8 +67,7 @@ class IRCManager:
         bot.reactor.add_global_handler("disconnect", self._on_disconnect)
         bot.reactor.add_global_handler("welcome", self._on_welcome)
 
-    @RateLimiter(max_calls=1, period=2)
-    def start(self):
+    def start(self) -> None:
         if self.conn is not None or self.ping_task is not None:
             raise AssertionError("start() should not be called while a connection is active")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ pylast==5.1.0
 pyOpenSSL==23.0.0 # for twisted.internet.ssl
 pytz==2022.7.1
 rapidfuzz==2.13.7
-ratelimiter==1.2.0.post0
 redis==4.5.1
 regex==2022.10.31
 requests==2.28.2


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

https://pypi.org/project/ratelimiter/

It was not updated for py3.11, and it was used for overly defensive
programming. We already assert if start is called incorrectly

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
