### PR TITLE
Remove known/verified bot support

### DIFF
--- a/configs/example.ini
+++ b/configs/example.ini
@@ -19,11 +19,7 @@ control_hub_id = 123456789
 ; as literal % signs.
 ; https://docs.python.org/3/library/configparser.html#interpolation-of-values
 db = postgresql+psycopg2:///pajbot?options=-c%%20search_path%%3Dpajbot1_streamer_name
-; set this to 1 if your bot is a verified bot (increased rate limits) on Twitch
-; More info about verified bots can be found here: https://dev.twitch.tv/docs/irc/guide#known-and-verified-bots
-;verified = 1
-; if your bot is known (increased rate limits, see same link above) set this to 1
-;known = 1
+
 ; Allows you to set a different output mode for whispers.
 ; `whisper_output_mode = normal` sends whispers as normal. (This is the default if you don't configure this option)
 ; `whisper_output_mode = disabled` will make it so the bot does not send any whispers. Outgoing whispers will be dropped.

--- a/pajbot/bot.py
+++ b/pajbot/bot.py
@@ -104,12 +104,7 @@ class Bot:
         RedisManager.init(redis_options)
         utils.wait_for_redis_data_loaded(RedisManager.get())
 
-        if cfg.get_boolean(config["main"], "verified", False):
-            self.tmi_rate_limits = TMIRateLimits.VERIFIED
-        elif cfg.get_boolean(config["main"], "known", False):
-            self.tmi_rate_limits = TMIRateLimits.KNOWN
-        else:
-            self.tmi_rate_limits = TMIRateLimits.BASE
+        self.tmi_rate_limits = TMIRateLimits.BASE
 
         self.whisper_output_mode = WhisperOutputMode.from_config_value(
             config["main"].get("whisper_output_mode", "normal")

--- a/pajbot/tmi.py
+++ b/pajbot/tmi.py
@@ -21,8 +21,6 @@ class WhisperOutputMode(Enum):
 
 class TMIRateLimits:
     BASE: TMIRateLimits
-    KNOWN: TMIRateLimits
-    VERIFIED: TMIRateLimits
 
     def __init__(self, privmsg_per_30: int, whispers_per_second: int, whispers_per_minute: int) -> None:
         self.privmsg_per_30 = privmsg_per_30
@@ -31,7 +29,5 @@ class TMIRateLimits:
 
 
 TMIRateLimits.BASE = TMIRateLimits(privmsg_per_30=90, whispers_per_second=2, whispers_per_minute=90)
-TMIRateLimits.KNOWN = TMIRateLimits(privmsg_per_30=90, whispers_per_second=2, whispers_per_minute=90)
-TMIRateLimits.VERIFIED = TMIRateLimits(privmsg_per_30=90, whispers_per_second=2, whispers_per_minute=90)
 
 CHARACTER_LIMIT = 500


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

As established in https://github.com/pajbot/pajbot/discussions/2339, there is no reason for the known/verified bot status to exist in pajbot. This PR removes it, but leaves the base code should there be any different "status'" in future.