### PR TITLE
Add setting to disable notifying the target of the Give Points command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bugfix: Fix bad assert in global CD checker. (#2363)
 - Minor: Add setting to control the delay of the rank refresh. (#2358)
+- Minor: Add setting to disable notifying the target of the Give Points command. (#2366)
 - Dev: Remove `ratelimiter` dependency, it was used to rate limit IRC connection creations which is not necessary any longer. (#2340)
 
 ## v1.63

--- a/pajbot/modules/givepoints.py
+++ b/pajbot/modules/givepoints.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import logging
 
 from pajbot import utils
@@ -6,6 +10,9 @@ from pajbot.managers.db import DBManager
 from pajbot.models.command import Command, CommandExample
 from pajbot.models.user import User
 from pajbot.modules import BaseModule, ModuleSetting
+
+if TYPE_CHECKING:
+    from pajbot.bot import Bot
 
 log = logging.getLogger(__name__)
 
@@ -41,7 +48,7 @@ class GivePointsModule(BaseModule):
         ),
     ]
 
-    def give_points(self, bot, source, message, **rest):
+    def give_points(self, bot: Bot, source: User, message: str, **rest) -> bool:
         if message is None or len(message) == 0:
             # The user did not supply any arguments
             return False
@@ -93,7 +100,9 @@ class GivePointsModule(BaseModule):
             bot.whisper(source, f"Successfully gave away {num_points} points to {target}")
             bot.whisper(target, f"{source} just gave you {num_points} points! You should probably thank them ;-)")
 
-    def load_commands(self, **options):
+            return True
+
+    def load_commands(self, **options) -> None:
         self.command_name = self.settings["command_name"].lower().replace("!", "").replace(" ", "")
         self.commands[self.command_name] = Command.raw_command(
             self.give_points,

--- a/pajbot/modules/givepoints.py
+++ b/pajbot/modules/givepoints.py
@@ -46,6 +46,13 @@ class GivePointsModule(BaseModule):
             required=True,
             default=False,
         ),
+        ModuleSetting(
+            key="notify_target",
+            label="Notify the target after they receive points",
+            type="boolean",
+            required=True,
+            default=True,
+        ),
     ]
 
     def give_points(self, bot: Bot, source: User, message: str, **rest) -> bool:
@@ -98,7 +105,9 @@ class GivePointsModule(BaseModule):
             target.points += num_points
 
             bot.whisper(source, f"Successfully gave away {num_points} points to {target}")
-            bot.whisper(target, f"{source} just gave you {num_points} points! You should probably thank them ;-)")
+
+            if self.settings["notify_target"] is True:
+                bot.whisper(target, f"{source} just gave you {num_points} points! You should probably thank them ;-)")
 
             return True
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

Tested & works as expected
![image](https://user-images.githubusercontent.com/962989/222856968-0315bc27-579f-4dd2-a673-9d18adaf66d8.png)

The default behaviour has not changed

I left the phrasing of the setting intentionally vague in case we move it over to a non-whisper target at some point

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
