### PR TITLE
Remove manual subscriber_fetch check for streamer ID

### DIFF
--- a/pajbot/modules/subscriber_fetch.py
+++ b/pajbot/modules/subscriber_fetch.py
@@ -56,8 +56,8 @@ class SubscriberFetchModule(BaseModule):
             else:
                 raise
 
-        # count how many subs we have (we don't want to count the broadcaster with his permasub)
-        sub_count = sum(1 for basics in subscribers if basics.id != self.bot.streamer.id)
+        # count how many subs we have, excluding the broadcaster with his permasub
+        sub_count = max(0, len(subscribers) - 1)
         self.bot.kvi["active_subs"].set(sub_count)
 
         with DBManager.create_session_scope() as db_session:


### PR DESCRIPTION
No reason to iterate over all the subscribers just to remove one item we know will be there, especially since only the count is used instead of the list itself.



Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
