### PR TITLE
Fix playsounds tab visibility on the admin page when the module was disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
+- Bugfix: Fix playsounds MenuItem not being vissible on the admin page, when the module was disabled. (#2469)
+
 ## v1.66
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
-- Bugfix: Fix playsounds MenuItem not being vissible on the admin page, when the module was disabled. (#2469)
+- Bugfix: Fix playsounds tab in the top navigation bar not being visible on the admin page when the module was disabled. (#2469)
 
 ## v1.66
 

--- a/pajbot/web/common/menu.py
+++ b/pajbot/web/common/menu.py
@@ -61,7 +61,7 @@ def init(app):
             MenuItem("/admin/timers", "admin_timers", "Timers"),
             MenuItem("/admin/moderators", "admin_moderators", "Moderators"),
             MenuItem("/admin/modules", "admin_modules", "Modules"),
-            MenuItem("/admin/playsounds", "admin_playsounds", "Playsounds", "playsound" in enabled_modules),
+            MenuItem("/admin/playsounds", "admin_playsounds", "Playsounds"),
             MenuItem("/admin/streamer", "admin_streamer", "Streamer Info"),
         ]
 


### PR DESCRIPTION
The "playsounds" menu tab is now always visible on the admins page.

I think this makes sense, since it would be nice to be able to edit the playsounds, without having to enable the module first.


Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
