### PR TITLE
Fix deprecated use of module loading in migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 
 - Bugfix: Fix playsounds tab in the top navigation bar not being visible on the admin page when the module was disabled. (#2469)
 - Bugfix: Multi-Raffle no longer raises an exception without picking any winners when the raffle ends. (#2492)
+- Dev: Fix deprecated use of `load_module` slated for removal in Python 3.12. (#2499)
 
 ## v1.66
 

--- a/pajbot/migration/migrate.py
+++ b/pajbot/migration/migrate.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
-import sys
 import importlib
-from importlib.abc import PathEntryFinder, MetaPathFinder
-from importlib.util import module_from_spec
 import logging
 import pkgutil
 import re
+from importlib.abc import MetaPathFinder, PathEntryFinder
+from importlib.util import module_from_spec
 
 from pajbot.migration.revision import Revision
 


### PR DESCRIPTION
Our old usage was slated for removal in Python 3.12

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

Tested by running the bot on a fresh schema and making sure all migrations ran expected.
And running it one more time did not fuck up the database in any way.

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
