### PR TITLE
Fix deprecated usage of redis.hmset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` w
 
 - Bugfix: Fix playsounds tab in the top navigation bar not being visible on the admin page when the module was disabled. (#2469)
 - Bugfix: Multi-Raffle no longer raises an exception without picking any winners when the raffle ends. (#2492)
+- Dev: Fix deprecated use of `redis.hmset`. (#2501)
 - Dev: Fix deprecated use of `load_module` slated for removal in Python 3.12. (#2499)
 - Dev: Add typing to the raffle module. (#2500)
 

--- a/pajbot/models/stream.py
+++ b/pajbot/models/stream.py
@@ -284,7 +284,7 @@ class StreamManager:
             f"{key_prefix}title": channel_information.title,
         }
 
-        redis.hmset("stream_data", stream_data)
+        redis.hset("stream_data", mapping=stream_data)
 
         self.game = channel_information.game_name
         self.title = channel_information.title

--- a/pajbot/models/stream.py
+++ b/pajbot/models/stream.py
@@ -345,7 +345,7 @@ class StreamManager:
                     log.info("Switching to offline state!")
                     self.go_offline()
 
-        redis.hmset("stream_data", stream_data)
+        redis.hset("stream_data", mapping=stream_data)
 
     def refresh_video_url_stage1(self) -> None:
         self.fetch_video_url_stage1()


### PR DESCRIPTION
The replacement is to just use redis.hset with the mapping kwarg, as can
be seen in the docs https://redis-py.readthedocs.io/en/stable/commands.html#redis.commands.core.CoreCommands.hset

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

Tested by manually looking at & messing with the `stream_data` redis key and seeing things update as expected

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
