### PR TITLE
Add minimum duel amount setting to the duel module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
+- Minor: Add minimum duel amount setting to the duel module. (#2508)
 - Bugfix: Fix playsounds tab in the top navigation bar not being visible on the admin page when the module was disabled. (#2469)
 - Bugfix: Multi-Raffle no longer raises an exception without picking any winners when the raffle ends. (#2492)
 - Dev: Fix deprecated use of `redis.hmset`. (#2501)

--- a/pajbot/managers/websocket.py
+++ b/pajbot/managers/websocket.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any, Dict, List
 
 import json
 import logging
@@ -114,7 +114,7 @@ class WebSocketManager:
         except:
             log.exception("Uncaught exception in WebSocketManager")
 
-    def emit(self, event, data={}):
+    def emit(self, event: Any, data: Dict[str, Any] = {}) -> None:
         if self.server:
             payload = json.dumps({"event": event, "data": data}).encode("utf8")
             for client in self.server.clients:

--- a/pajbot/modules/duel.py
+++ b/pajbot/modules/duel.py
@@ -82,7 +82,11 @@ class DuelModule(BaseModule):
             constraints={"min_value": 0, "max_value": 240},
         ),
         ModuleSetting(
-            key="show_on_clr", label="Show duels on the clr overlay", type="boolean", required=True, default=True
+            key="show_on_clr",
+            label="Show duels on the clr overlay",
+            type="boolean",
+            required=True,
+            default=True,
         ),
         ModuleSetting(
             key="max_duel_age",

--- a/pajbot/modules/duel.py
+++ b/pajbot/modules/duel.py
@@ -385,7 +385,7 @@ class DuelModule(BaseModule):
                 bot.whisper(source, "You have no duel request or duel target. Type !duel USERNAME POT to duel someone!")
 
     @staticmethod
-    def get_duel_stats(bot: Bot, source: User, **rest: Any) -> None:
+    def get_duel_stats(bot: Bot, source: User, **rest: Any) -> bool:
         """
         Whispers the users duel winratio to the user
         """
@@ -397,6 +397,8 @@ class DuelModule(BaseModule):
             source,
             f"duels: {source.duel_stats.duels_total} winrate: {source.duel_stats.winrate:.2f}% streak: {source.duel_stats.current_streak} profit: {source.duel_stats.profit}",
         )
+
+        return True
 
     def _cancel_expired_duels(self) -> None:
         if self.bot is None:

--- a/pajbot/utils/__init__.py
+++ b/pajbot/utils/__init__.py
@@ -21,3 +21,31 @@ from .time_limit import time_limit
 from .time_method import time_method
 from .time_since import time_since
 from .wait_for_redis_data_loaded import wait_for_redis_data_loaded
+
+__all__ = [
+    "clean_up_message",
+    "datetime_from_utc_milliseconds",
+    "dump_threads",
+    "extend_version_if_possible",
+    "extend_version_with_git_data",
+    "find",
+    "get_class_that_defined_method",
+    "init_logging",
+    "iterate_in_chunks",
+    "iterate_split_with_index",
+    "load_config",
+    "now",
+    "parse_args",
+    "parse_number_from_string",
+    "parse_points_amount",
+    "print_traceback",
+    "remove_none_values",
+    "split_into_chunks_with_prefix",
+    "stringify_tweet",
+    "time_ago",
+    "time_limit",
+    "time_method",
+    "time_since",
+    "tweet_provider_stringify_tweet",
+    "wait_for_redis_data_loaded",
+]


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

Changes:

- typing: `get_duel_stats` return bool
- typing: `pajbot.utils` - define `__all__` for explicit exports
- typing: `pajbot.managers.websocket` typing for `emit` function
- format: move each attribute to its own line for `show_on_clr`
- Add minimum point amount to the duel module

I have decided not to change anything with the output, it's still hardcoded as whispers for error messages.
If we want to change this, it should be a new feature request.

Fixes #2400

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
