### PR TITLE
don't filter out disabled commands when rebuilding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
+- Minor: Disabled commands are now included in the admin command list. They can be re-enabled by pressing "Edit" & checking the Enabled checkbox. (#2664)
 - Bugfix: Fixed whispers being unable to be sent breaking commands. (#2624)
 
 ## v1.68

--- a/pajbot/managers/command.py
+++ b/pajbot/managers/command.py
@@ -388,7 +388,7 @@ class CommandManager(UserDict[str, Command]):
                     out[alias] = command
 
         self.data = {}
-        db_commands = {alias: command for alias, command in self.db_commands.items() if command.enabled is True}
+        db_commands = {alias: command for alias, command in self.db_commands.items()}
 
         merge_commands(self.internal_commands, self.data)
         merge_commands(db_commands, self.data)

--- a/pajbot/models/command.py
+++ b/pajbot/models/command.py
@@ -536,6 +536,14 @@ class WebCommand:
         return self._command.level
 
     @property
+    def enabled(self) -> bool:
+        return self._command.enabled
+
+    @property
+    def disabled(self) -> bool:
+        return not self.enabled
+
+    @property
     def mod_only(self) -> bool:
         return self._command.mod_only
 

--- a/templates/admin/commands.html
+++ b/templates/admin/commands.html
@@ -46,7 +46,7 @@
         </tr>
         <tr data-id="{{command.id}}">
             <td class="collapsing"></td>
-            <td colspan="3">{% if command.data.last_date_used != None and command.data.last_date_used != '' %}Last time used <strong>{{ command.data.last_date_used|time_ago }}</strong> ago.{% else %}No Data.{% endif %} {% include 'admin/helper/command_user.html' %}</td>
+            <td colspan="3">{%- if command.disabled %}<span style="color: red; font-weight: bold;">DISABLED</span> {% endif -%}{% if command.data.last_date_used != None and command.data.last_date_user != '' %}Last time used <strong>{{ command.data.last_date_used|time_ago }}</strong> ago.{% else %}No Data.{% endif %} {% include 'admin/helper/command_user.html' %}</td>
         </tr>
         {% endfor %}
         </tbody>
@@ -75,7 +75,7 @@
         <tr data-id="{{command.id}}">
             <td class="collapsing"></td>
             <td class="collapsing"></td>
-            <td colspan="3">{% if command.data.last_date_used != None %}Last time used <strong>{{ command.data.last_date_used|time_ago }}</strong> ago.{% else %}No Data.{% endif %} {% include 'admin/helper/command_user.html' %}</td>
+            <td colspan="3">{%- if command.disabled %}<span style="color: red; font-weight: bold;">DISABLED</span> {% endif -%}{% if command.data.last_date_used != None and command.data.last_date_user != '' %}Last time used <strong>{{ command.data.last_date_used|time_ago }}</strong> ago.{% else %}No Data.{% endif %} {% include 'admin/helper/command_user.html' %}</td>
             </tr>
         {% endfor %}
         </tbody>
@@ -101,7 +101,7 @@
         </tr>
         <tr data-id="{{command.id}}">
             <td class="collapsing"></td>
-            <td colspan="3">{% if command.data.last_date_used != None %}Last time used <strong>{{ command.data.last_date_used|time_ago }}</strong> ago.{% else %}No Data.{% endif %} {% include 'admin/helper/command_user.html' %}</td>
+            <td colspan="3">{%- if command.disabled %}<span style="color: red; font-weight: bold;">DISABLED</span> {% endif -%}{% if command.data.last_date_used != None and command.data.last_date_user != '' %}Last time used <strong>{{ command.data.last_date_used|time_ago }}</strong> ago.{% else %}No Data.{% endif %} {% include 'admin/helper/command_user.html' %}</td>
         </tr>
         {% endfor %}
         </tbody>


### PR DESCRIPTION
This inadvertently hid commands that were disabled from the web UI. db_commands already filters out disabled commands, if so desired, through options["enabled"] (currently L353).

(ONLY DONE MINIMAL TESTING)