### PR TITLE
fix(install docs): Nginx - use separate http2 directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
 
- - Documentation: Fixed example nginx config's http2 support for Nginx v1.26+. (#2804)
+- Documentation: Fixed example nginx config's http2 support for Nginx v1.26+. (#2804)
 
 ## v1.70
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unversioned
 
+Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!
+
+ - Documentation: Fixed example nginx config's http2 support for Nginx v1.26+. (#2804)
+
 ## v1.70
 
 Remember to bring your dependencies up to date with `./scripts/venvinstall.sh` when updating to this version!

--- a/install-docs/nginx-example.conf
+++ b/install-docs/nginx-example.conf
@@ -7,8 +7,9 @@ upstream streamer_name-websocket {
 }
 
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    http2 on;
+    listen 443 ssl;
+    listen [::]:443 ssl;
 
     ssl_certificate /etc/letsencrypt/live/your-domain.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/your-domain.com/privkey.pem;


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

Using `http2` parameter in the listen directive has been deprecated as of nginx 1.25.1 (released June 2023).
Parameter should be removed and the [`http2` directive](https://nginx.org/en/docs/http/ngx_http_v2_module.html#http2) should be used instead

Taken from https://nginx.org/en/CHANGES-1.26 :
```
    *) Feature: the "http2" directive, which enables HTTP/2 on a per-server
       basis; the "http2" parameter of the "listen" directive is now
       deprecated.
```
