### PR TITLE
deps: bump marshmallow to 3.25.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ jsmin==3.0.1
 Markdown==3.7
 MarkupSafe==2.1.5
 marshmallow-dataclass==8.7.1
-marshmallow==3.22.0
+marshmallow==3.25.1
 psycopg2==2.9.11
 pylast==5.3.0
 pyOpenSSL==26.0.0 # for twisted.internet.ssl


### PR DESCRIPTION
cannot bump to later unfortunately



Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
