### PR TITLE
test: config.get_boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The supported Python versions are now 3.11, 3.11, 3.12, 3.13, and 3.14.
 - Dev: Added some unit tests for \$(randomchoice:...). (#2839)
 - Dev: Added a `test.sh` script that errors if we use something deprecated. (#2855)
 - Dev: Added unit test for `utils.now`. (#2856)
+- Dev: Added unit test for `config.get_boolean`. (#2860)
 - Dev: Remove dependency on the `cgi` package. (#2827)
 - Dev: Requirement files are now sourced from pyproject.toml. `uv` is recommended to install dependencies. (#2826, #2841)
 - Dev: Use our own fork of `pytimeparse` to ensure we don't error to fix Python3.14 deprecation warnings. (#2857)

--- a/pajbot/config.py
+++ b/pajbot/config.py
@@ -113,6 +113,8 @@ def load_admin_id_or_login(config: Config) -> Union[tuple[str, None], tuple[None
 
 
 def get_boolean(o: ConfigSection, key: str, default_value: bool) -> bool:
-    v = o.get(key, default_value)
+    v = o.get(key)
+    if v is None:
+        return default_value
 
     return v == "1"

--- a/pajbot/tests/test_config.py
+++ b/pajbot/tests/test_config.py
@@ -1,0 +1,12 @@
+from pajbot import config
+
+import pytest
+
+
+def test_get_boolean() -> None:
+    cfg = {"enabled": "1", "disabled": "0"}
+
+    assert config.get_boolean(cfg, "enabled", False) is True
+    assert config.get_boolean(cfg, "disabled", True) is False
+    assert config.get_boolean(cfg, "forsen", True) is True
+    assert config.get_boolean(cfg, "forsen", False) is False

--- a/pajbot/tests/test_config.py
+++ b/pajbot/tests/test_config.py
@@ -1,6 +1,5 @@
 from pajbot import config
 
-import pytest
 
 
 def test_get_boolean() -> None:

--- a/pajbot/tests/test_config.py
+++ b/pajbot/tests/test_config.py
@@ -1,7 +1,6 @@
 from pajbot import config
 
 
-
 def test_get_boolean() -> None:
     cfg = {"enabled": "1", "disabled": "0"}
 


### PR DESCRIPTION
it was wrong before xd default value was essentially not used

Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Documentation in docs/ or install-docs/ was updated, if applicable
- [x] I have tested all changes

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
